### PR TITLE
Added baseclasses for allow_None and Tuple

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -755,9 +755,8 @@ class Boolean(SupportsAllowNone):
         super(Boolean,self).__set__(obj,val)
 
 
-
-class NumericTuple(SupportsAllowNone):
-    """A numeric tuple Parameter (e.g. (4.5,7.6,3)) with a fixed tuple length."""
+class Tuple(SupportsAllowNone):
+    """A tuple Parameter (e.g. (4.5,7.6,3)) with a fixed tuple length."""
 
     __slots__ = ['length']
 
@@ -787,14 +786,24 @@ class NumericTuple(SupportsAllowNone):
         if not len(val)==self.length:
             raise ValueError("%s: tuple is not of the correct length (%d instead of %d)." %
                              (self._attrib_name,len(val),self.length))
-        for n in val:
-            if not _is_number(n):
-                raise ValueError("%s: tuple element is not numeric: %s." % (self._attrib_name,str(n)))
 
 
     def __set__(self,obj,val):
         self._check(val)
-        super(NumericTuple,self).__set__(obj,val)
+        super(Tuple,self).__set__(obj,val)
+
+
+
+class NumericTuple(Tuple):
+    """A numeric tuple Parameter (e.g. (4.5,7.6,3)) with a fixed tuple length."""
+
+    __slots__ = []
+
+    def _check(self,val):
+        super(NumericTuple)._check(val)
+        for n in val:
+            if not _is_number(n):
+                raise ValueError("%s: tuple element is not numeric: %s." % (self._attrib_name,str(n)))
 
 
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -514,14 +514,25 @@ class Parameter(object):
             setattr(self,k,v)
 
 
-# Define one particular type of Parameter that is used in this file
-class String(Parameter):
+
+class SupportsAllowNone(Parameter):
+    """
+    Parameter that can optionally be set to allow None.
+    """
     __slots__ = ['allow_None']
 
-    def __init__(self,default="",allow_None=False,**params):
-        """Initialize a string parameter."""
+    def __init__(self,default,allow_None=False,**params):
         Parameter.__init__(self,default=default,**params)
         self.allow_None = (default is None or allow_None)
+
+
+
+class String(SupportsAllowNone):
+    """
+    A simple String parameter.
+    """
+
+    __slots__ = []
 
     def __set__(self,obj,val):
         if not isinstance(val,str) and not (self.allow_None and val is None):


### PR DESCRIPTION
In response to the recent issue https://github.com/ioam/param/issues/74 and the general annoyance with allow_None being only supported by a few Parameters I've created a SupportsAllowNone baseclass as Jim suggested. Additionally I've added a Tuple parameter as the baseclass for NumericTuple.