### PR TITLE
Added seed parameter to RandomDistribution number generators

### DIFF
--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -315,6 +315,9 @@ class TimeAwareRandomState(TimeAware):
         """
         if seed is None: # Equivalent to an uncontrolled seed.
             seed = random.Random().randint(0, 1000000)
+            suffix = ''
+        else:
+            suffix = str(seed)
 
         # If time_dependent, independent state required: otherwise
         # time-dependent seeding (via hash) will affect shared
@@ -330,10 +333,8 @@ class TimeAwareRandomState(TimeAware):
         if name is None:
             self._verify_constrained_hash()
 
-        if seed is not None:
-            name = '%s%s' % (name, seed)
-
-        self._hashfn = Hash(name if name else self.name, input_count=2)
+        hash_name = name if name else self.name
+        self._hashfn = Hash(hash_name+suffix, input_count=2)
 
         if self.time_dependent:
             self._hash_and_seed()

--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -391,7 +391,7 @@ class RandomDistribution(NumberGenerator, TimeAwareRandomState):
     Note: Each RandomDistribution object has independent random state.
     """
 
-    seed = param.Number(default=None, allow_None=True, doc="""
+    seed = param.Integer(default=None, allow_None=True, doc="""
        Sets the seed of the random number generator and can be used to
        randomize time dependent streams.
 

--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -329,6 +329,10 @@ class TimeAwareRandomState(TimeAware):
 
         if name is None:
             self._verify_constrained_hash()
+
+        if seed is not None:
+            name = '%s%s' % (name, seed)
+
         self._hashfn = Hash(name if name else self.name, input_count=2)
 
         if self.time_dependent:
@@ -386,6 +390,13 @@ class RandomDistribution(NumberGenerator, TimeAwareRandomState):
     Note: Each RandomDistribution object has independent random state.
     """
 
+    seed = param.Number(default=None, allow_None=True, doc="""
+       Sets the seed of the random number generator and can be used to
+       randomize time dependent streams.
+
+       If seed is None, there is no control over the random stream
+       (i.e. no reproducibility of the stream).""")
+
     __abstract = True
 
     def __init__(self,**params):
@@ -399,9 +410,8 @@ class RandomDistribution(NumberGenerator, TimeAwareRandomState):
 
         Note that any supplied seed is ignored if time_dependent=True.
         """
-        seed = params.pop('seed', None)
         super(RandomDistribution,self).__init__(**params)
-        self._initialize_random_state(seed=seed, shared=False)
+        self._initialize_random_state(seed=self.seed, shared=False)
 
     def __call__(self):
         if self.time_dependent:

--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -409,8 +409,6 @@ class RandomDistribution(NumberGenerator, TimeAwareRandomState):
         If seed=X is specified, sets the Random() instance's seed.
         Otherwise, calls creates an unseeded Random instance which is
         likely to result in a state very different from any just used.
-
-        Note that any supplied seed is ignored if time_dependent=True.
         """
         super(RandomDistribution,self).__init__(**params)
         self._initialize_random_state(seed=self.seed, shared=False)

--- a/numbergen/__init__.py
+++ b/numbergen/__init__.py
@@ -334,7 +334,8 @@ class TimeAwareRandomState(TimeAware):
             self._verify_constrained_hash()
 
         hash_name = name if name else self.name
-        self._hashfn = Hash(hash_name+suffix, input_count=2)
+        if not shared:  hash_name += suffix
+        self._hashfn = Hash(hash_name, input_count=2)
 
         if self.time_dependent:
             self._hash_and_seed()


### PR DESCRIPTION

Adds an explicit seed parameter for random number generators. This seed will now also control time-dependent random streams (previously you had to mangle the name with the seed yourself).

I have tested that this works with the updated SOM tutorial (time dependent streams for the input generator)  but I cannot guarantee that this won't break everything else!