### PR TITLE
Added pprint function to parameterized.py

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1188,8 +1188,8 @@ class Parameterized(object):
                 raise Exception("Argument %r is not a parameter "
                                 "and has an unknown value." % k)
 
-            # Explicit kwarg (unchanged)
-            if (k in kwargs) and kwargs[k] == value: continue
+            # Explicit kwarg (unchanged, known value)
+            if (k in kwargs) and (k in values) and kwargs[k] == values[k]: continue
 
             if k in posargs:
                 # The value repr is used for positional arguments

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -129,7 +129,9 @@ def pprint(obj, including={}, exclude=['self', 'name']):
             # Explicit keyword arguments that have changed
             arglist.append(k)
             defaults.append(values[k])
-        elif spec.keywords is not None:
+        elif k in kwargs:
+            continue
+        elif (spec.keywords is not None):
             # Parameters ordered by precendence (if **kwargs present)
             arglist.append(k)
             defaults.append(values[k])

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1168,7 +1168,9 @@ class Parameterized(object):
 
         ordering = sorted(
             sorted(changed_params.keys()), # alphanumeric tie-breaker
-            key=lambda k: self.params(k).precedence)
+            key=lambda k: (- float('inf')  # No precedence is lowest possible precendence
+                           if self.params(k).precedence is None
+                           else self.params(k).precedence))
 
         values = dict(self.get_param_values())
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -804,6 +804,8 @@ def script_repr(val,imports, prefix="\n    ", settings=[],
     """
     # CB: doc prefix & settings or realize they don't need to be
     # passed around, etc.
+    # JLS: The settings argument is not used anywhere. To be removed
+    # in a separate PR.
     if isinstance(val,type):
         rep = type_script_repr(val,imports,prefix,settings)
 
@@ -811,10 +813,8 @@ def script_repr(val,imports, prefix="\n    ", settings=[],
         rep = script_repr_reg[type(val)](val,imports,prefix,settings)
 
     elif hasattr(val,'script_repr'):
-        rep=val.script_repr(imports=imports,
-                            prefix=prefix+"    ",
-                            qualify=True,
-                            unknown_value=unknown_value)
+        rep=val.script_repr(imports=imports, prefix=prefix+"    ",
+                            qualify=True, unknown_value=unknown_value)
 
     else:
         rep=repr(val)
@@ -1181,9 +1181,7 @@ class Parameterized(object):
                                 re.match('^'+self.__class__.__name__+'[0-9]+$', values[k])):
                 continue
 
-            value = script_repr(values[k], imports,
-                                prefix=prefix,
-                                settings=[],
+            value = script_repr(values[k], imports, prefix=prefix,settings=[],
                                 unknown_value=unknown_value,
                                 qualify=qualify) if k in values else unknown_value
             if value is None:
@@ -1196,12 +1194,11 @@ class Parameterized(object):
             if k in posargs:
                 # The value repr is used for positional arguments
                 arglist.append(value)
-            elif k in kwargs:
-                # Explicit keyword argument (changed)
+            elif k in kwargs or (spec.keywords is not None):
+                # Explicit modified keywords or parameters in
+                # precendence order (if **kwargs present)
                 keywords.append('%s=%s' % (k, value))
-            elif (spec.keywords is not None):
-                # Parameters ordered by precendence (if **kwargs present)
-                keywords.append('%s=%s' % (k, value))
+
             processed.append(k)
 
         qualifier = mod + '.'  if qualify else ''

--- a/tests/testparameterizedrepr.py
+++ b/tests/testparameterizedrepr.py
@@ -1,0 +1,121 @@
+"""
+Unit test for the repr and script_repr of parameterized objects.
+"""
+
+import unittest
+import param
+
+
+
+class TestParameterizedRepr(unittest.TestCase):
+
+    def setUp(self):
+        # initialize a parameterized class
+        class A(param.Parameterized):
+            a = param.Number(4, precedence=-5)
+            b = param.String('B', precedence=-4)
+            c = param.Number(4, precedence=0)
+            d = param.Integer(-22, precedence=1)
+
+            x = param.Number(1, precedence=2)
+            y = param.Number(2, precedence=-1)
+            z = param.Number(3, precedence=-2)
+            def __init__(self, a, b, c=4, d=-22, **kwargs):
+                super(A, self).__init__(a=a, b=b, c=c, **kwargs)
+
+        self.A = A
+
+        class B(param.Parameterized):  # Similar to A but no **kwargs
+            a = param.Number(4, precedence=-5)
+            b = param.String('B', precedence=-4)
+            c = param.Number(4, precedence=0)
+            d = param.Integer(-22, precedence=1)
+
+            x = param.Number(1, precedence=2)
+            def __init__(self, a, b, c=4, d=-22):
+                super(B, self).__init__(a=a, b=b, c=c, name='ClassB')
+
+        self.B = B
+
+        class C(param.Parameterized):  # Similar to A but with *varargs
+            a = param.Number(4, precedence=-5)
+            b = param.String('B', precedence=-4)
+            c = param.Number(4, precedence=0)
+            d = param.Integer(-22, precedence=1)
+
+            x = param.Number(1, precedence=2)
+            y = param.Number(2, precedence=-1)
+            z = param.Number(3, precedence=-2)
+
+            def __init__(self, a, b, c=4, d=-22, *varargs, **kwargs):
+                super(C, self).__init__(a=a, b=b, c=c, **kwargs)
+
+        self.C = C
+
+
+        class D(param.Parameterized):  # Similar to A but with missing parameters
+            a = param.Number(4, precedence=-5)
+            b = param.String('B', precedence=-4)
+
+            def __init__(self, a, b, c=4, d=-22, **kwargs):
+                super(D, self).__init__(a=a, b=b, **kwargs)
+
+        self.D = D
+
+
+    def testparameterizedrepr(self):
+        obj = self.A(4,'B', name='test1')
+        self.assertEqual(repr(obj),
+                         "A(a=4, b='B', c=4, d=-22, name='test1', x=1, y=2, z=3)")
+
+    def testparameterizedscriptrepr1(self):
+        obj = self.A(4,'B', name='test')
+        self.assertEqual(obj.script_repr(),
+                         "A(4, 'B', name='test')")
+
+    def testparameterizedscriptrepr2(self):
+        obj = self.A(4,'B', c=5, name='test')
+        self.assertEqual(obj.script_repr(),
+                         "A(4, 'B', c=5, name='test')")
+
+    def testparameterizedscriptrepr3(self):
+        obj = self.A(4,'B', c=5,  x=True, name='test')
+        self.assertEqual(obj.script_repr(),
+                         "A(4, 'B', c=5, name='test')")
+
+    def testparameterizedscriptrepr4(self):
+        obj = self.A(4,'B', c=5,  x=10, name='test')
+        self.assertEqual(obj.script_repr(),
+                         "A(4, 'B', c=5, name='test', x=10)")
+
+
+    def testparameterizedscriptrepr5(self):
+        obj = self.A(4,'B', x=10, y=11, z=12, name='test')
+        self.assertEqual(obj.script_repr(),
+                         "A(4, 'B', name='test', z=12, y=11, x=10)")
+
+    def testparameterizedscriptrepr_nokwargs(self):
+        obj = self.B(4,'B', c=99)
+        obj.x = 10 # Modified but not passable through constructor
+        self.assertEqual(obj.script_repr(),
+                         "B(4, 'B', c=99)")
+
+    def testparameterizedscriptrepr_varags(self):
+        obj = self.C(4,'C', c=99)
+        self.assertEqual(obj.script_repr(),
+                         "C(4, 'C', c=99, **varargs)")
+
+    def testparameterizedscriptrepr_varags_kwargs(self):
+        obj = self.C(4,'C', c=99, x=10, y=11, z=12)
+        self.assertEqual(obj.script_repr(),
+                         "C(4, 'C', c=99, z=12, y=11, x=10, **varargs)")
+
+    def testparameterizedscriptrepr_missing_values(self):
+        obj = self.D(4,'D', c=99)
+        self.assertEqual(obj.script_repr(),
+                         "D(4, 'D', c=<?>, d=<?>)")
+
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()


### PR DESCRIPTION

This PR adds something I've long wished for in param: sensible, short reprs that actually work. :-)

Although I started implementing this in ``__repr__``,  I saw the note about ``repr`` needing to be fast and then decided against implementing it there once I realized what was required.

Instead of changing ``__repr__``, I've ended up making a more robust ``pprint`` function that can be used as follows:


```python
class Foo(param.Parameterized):
    
    a = param.Number(4, precedence=6)
    
    b = param.String('B', precedence=-9)
    
    c = param.Number(4, precedence=0)
    
    z = param.Number(4, precedence=0)
    
    def __init__(self, a, b, c=4, d=99, **kwargs):
        self.d = d
        super(Foo, self).__init__(a=a, b=b, c=c, **kwargs)
        
    def __repr__(self):
        return param.parameterized.pprint(self, {'d':self.d})
```

First the positional arguments are shown as their appropriate values. Then modified keyword arguments are shown in the order they are declared in. Then the ``varargs`` (e.g ``*varargs``) is shown (if present). Then if a keyword dictionary (i.e. **kwargs) is present, it is assumed that the modified parameters can then be listed in order of their precedence.

Here are some examples:

```python
>>> Foo(1,'C')
Foo(1, 'C')

# Positional arguments always shown even if at default values
>>> Foo(4,'B')  
Foo(4,'B')

# Keyword not shown if supplied at default value
>>> Foo(4,'B', c=4) 
Foo(4,'B')

>>> Foo(4, 'B', c=5)
Foo(4, 'B', c=5)

# 'd' is not a parameter (supplied at the default value)
>>> Foo(4,'B', c=5, d=99)   
Foo(4, 'B', c=5)

>>> Foo(4,'B', c=5, d=100)
 Foo(4,'B', c=5, d=100)

>>>  Foo(4,'B', z=44, d=100)
 Foo(4,'B', z=44, d=100)

>>>  Foo(4,'B', z=4, d=100)
Foo(4, 'B', d=100)
```

For comparison, here is an example of the default repr:

```python
>>>Foo(4,'B')
Foo(a=4, b='B', c=4, name='Foo00456', z=4)
```

My main concern with ``pprint`` is performance. It might be nice to cache some of the results of the introspection for performance reasons.

EDIT: If you are happy with the addition of this function, I'll make sure to write a good number of unit tests for it.