### PR TITLE
Unicode support for param.String

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -5,6 +5,7 @@ messaging.
 
 import copy
 import re
+import sys
 
 from operator import itemgetter,attrgetter
 from types import FunctionType
@@ -521,13 +522,15 @@ class String(Parameter):
     A simple String parameter.
     """
 
+    basestring = basestring if sys.version_info[0]==2 else str
+
     def __init__(self, default="", allow_None=False, **kwargs):
         super(String, self).__init__(default=default, allow_None=allow_None, **kwargs)
         self._check_value(default)
         self.allow_None = allow_None
 
     def _check_value(self,val):
-        if not isinstance(val,str) and not (self.allow_None and val is None):
+        if not isinstance(val, self.basestring) and not (self.allow_None and val is None):
             raise ValueError("String '%s' only takes a string value."%self._attrib_name)
 
     def __set__(self,obj,val):


### PR DESCRIPTION
This commit adds unicode support for param.String, which has been requested on multiple occasions, see https://github.com/ioam/param/issues/73 and https://github.com/ioam/holoviews/issues/29. This is the simplest possible fix that will get param to support Unicode strings in Python 2.

To handle unicode correctly consistently we should consider importing: ```from future import unicode_literals``` everywhere, but I'm not sure what the implications of that change would be.

The fully verbose version providing compatibility for all string, bytes and unicode types is the following but that's probably overkill:

```
try:
    unicode = unicode
except NameError:
    # 'unicode' is undefined, must be Python 3
    str = str
    unicode = str
    bytes = bytes
    basestring = (str,bytes)
else:
    # 'unicode' exists, must be Python 2
    str = str
    unicode = unicode
    bytes = str
    basestring = basestring
```