### PR TITLE
Enabled cythonizing of param modules if Cython is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "pypy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[build_ext]
+inplace=1

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
+try:
+    from Cython.Build import cythonize
+    ext_modules = cythonize("param/*.py", exclude=['param/ipython.py'])
+except:
+    ext_modules = []
+
 setup_args = {}
 
 setup_args.update(dict(
@@ -16,8 +22,9 @@ setup_args.update(dict(
     long_description=open('README.rst').read() if os.path.isfile('README.rst') else 'Consult README.rst',
     author= "IOAM",
     author_email= "developers@topographica.org",
-    maintainer= "IOAM",
-    maintainer_email= "developers@topographica.org",
+    ext_modules=ext_modules,
+    maintainer="IOAM",
+    maintainer_email="developers@topographica.org",
     platforms=['Windows', 'Mac OS X', 'Linux'],
     license='BSD',
     url='http://ioam.github.com/param/',


### PR DESCRIPTION
This small PR enables cythonizing for the param ``__init__``, ``parameterized`` and ``version`` modules. The IPython module has too much magic in it to be supported. Overall this already provides roughly a 50% speedup when creating new parameterized objects (measured by creating 20k HoloViews Images). In future we could go further and actually rewrite some parts of param as actual Cython, but I suspect that may not be worth it given the decent speedup without it and that most of the remaining time is spent deep copying default parameter values, which can in some cases be avoided by setting ``instantiate`` to ``False`` on a parameter.