### PR TITLE
Add shared parameter context manager

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -22,6 +22,7 @@ from .parameterized import Parameterized, Parameter, String, \
      descendents, ParameterizedFunction, ParamOverrides
 
 from .parameterized import logging_level # pyflakes:ignore (needed for eval)
+from .parameterized import shared_parameters # pyflakes:ignore (needed for eval)
 
 
 # Determine up-to-date version information, if possible, but with a

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -315,12 +315,12 @@ class TestSharedParameters(unittest.TestCase):
             self.ap2 = AnotherTestPO(name='B', print_level=0)
 
     def test_shared_object(self):
-        self.assertIs(self.ap1.instPO, self.ap2.instPO)
-        self.assertIsNot(self.ap1.params('instPO').default, self.ap2.instPO)
+        self.assertTrue(self.ap1.instPO is self.ap2.instPO)
+        self.assertTrue(self.ap1.params('instPO').default is not self.ap2.instPO)
 
     def test_shared_list(self):
-        self.assertIs(self.p1.inst, self.p2.inst)
-        self.assertIsNot(self.p1.params('inst').default, self.p2.inst)
+        self.assertTrue(self.p1.inst is self.p2.inst)
+        self.assertTrue(self.p1.params('inst').default is not self.p2.inst)
 
 
 

--- a/tests/testparameterizedobject.py
+++ b/tests/testparameterizedobject.py
@@ -28,7 +28,7 @@ import random
 from nose.tools import istest, nottest
 
 
-from param.parameterized import ParamOverrides
+from param.parameterized import ParamOverrides, shared_parameters
 
 @nottest
 class _SomeRandomNumbers(object):
@@ -303,6 +303,25 @@ class TestParamOverrides(unittest.TestCase):
             raise AssertionError("ParamOverrides should give AttributeError when key can't be found.")
         else:
             raise AssertionError("Test supposed to lookup non-existent attribute and raise error.")
+
+
+class TestSharedParameters(unittest.TestCase):
+
+    def setUp(self):
+        with shared_parameters():
+            self.p1 = TestPO(name='A', print_level=0)
+            self.p2 = TestPO(name='B', print_level=0)
+            self.ap1 = AnotherTestPO(name='A', print_level=0)
+            self.ap2 = AnotherTestPO(name='B', print_level=0)
+
+    def test_shared_object(self):
+        self.assertIs(self.ap1.instPO, self.ap2.instPO)
+        self.assertIsNot(self.ap1.params('instPO').default, self.ap2.instPO)
+
+    def test_shared_list(self):
+        self.assertIs(self.p1.inst, self.p2.inst)
+        self.assertIsNot(self.p1.params('inst').default, self.p2.inst)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the ``shared_parameters`` context manager. Here's the docstring, which should explain what it does:

Context manager to share parameter instances when creating
multiple Parameterized objects of the same type. Parameter default
values are instantiated once and cached to be reused when another
Parameterized object of the same type is instantiated.
Can be useful to easily modify large collections of Parameterized
objects at once and can provide a significant speedup.

I've done some basic profiling and this can be a significant boost when instantiating a lot of complex objects.

```python
%%timeit
with param.parameterized.shared_parameters():
    hmap = hv.HoloMap({i: hv.Image(np.random.rand(10,10)) for i in range(10000)})
```

```
1 loop, best of 3: 1.77 s per loop
```

vs.

```python
%%timeit
hv.HoloMap({i: hv.Image(np.random.rand(10,10)) for i in range(10000)})
```

```
1 loop, best of 3: 3.86 s per loop
```

There's many cases where this might be useful, particularly holoviews where many operations create a lot of identical objects (e.g. groupby). Sharing a parameter value can also be useful in it's own right since you could change the dimensions of all the elements at once (although I might not recommend it):

```python
with param.shared_parameters():
    hmap = hv.HoloMap({i: hv.Image(np.random.rand(10,10)) for i in range(10000)})
hmap.last.kdims[:] = [hv.Dimension('A'), hv.Dimension('B')]
```