### PR TITLE
Skip processing non-parameterized classes in setup_param

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1392,6 +1392,8 @@ class Parameterized(object):
         #  a later-overridden parent class's parameter)
         params_to_instantiate = {}
         for class_ in classlist(type(self)):
+            if not issubclass(class_, Parameterized):
+                continue
             for (k,v) in class_.__dict__.items():
                 # (avoid replacing name with the default of None)
                 if isinstance(v,Parameter) and v.instantiate and k!="name":


### PR DESCRIPTION
Very minor addition, which gives an easy 5-10% speedup in creating Parameterized objects. Between this, the ``shared_defaults`` context manager, and Cython we can now squeeze out a 3x speedup when creating HoloViews Image Elements.