### PR TITLE
Ordered selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ notifications:
   email:
     on_failure: change # [always|never|change] default: always
 
-# no dependencies (coveralls, ipython, flake8 only needed for testing)
+# no dependencies for py2.7+ (coveralls, ipython, flake8 only needed for testing)
 install:
   - pip install coveralls flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -182,14 +182,14 @@ Release Notes
 Notable additions, or changes that may require users to alter code,
 are listed below.
 
-1.3.3 (2016/07)
+1.4.0 (2016/07)
 _______________
 
 * Added support for new (`ParamNB<https://github.com/ioam/paramnb>`_) ParamNB project
 * Added new parameter types Action, FileSelector, and ListSelector
 
 A full list of changes since the previous release is available 
-`on GitHub <https://github.com/ioam/param/compare/v1.3.2...v1.3.3>`_.
+`on GitHub <https://github.com/ioam/param/compare/v1.3.2...v1.4.0>`_.
 
 
 1.3.2 (2015/04)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -79,7 +79,18 @@ included as part of larger projects without adding external dependencies.
 Parameters make GUI programming simpler
 _______________________________________
 
-Parameters make it simple to generate GUIs. An interface for Tk already exists (`ParamTk <http://ioam.github.com/paramtk/>`_), providing a property sheet that can automatically generate a GUI window for viewing and editing an object's Parameters.
+Parameters make it simple to generate GUIs by separating your semantic
+information (what is this parameter? what type can it have? does it
+have bounds?) from anything to do with a particular GUI library.  To
+use Parameters in a particular GUI toolkit, you just need to write a
+simple set of interfaces that indicate how a given Parameter type
+should be displayed, and what widgets to generate for it.  Currently,
+interfaces are provided for use in Jupyter Notebooks (`ParamNB
+<https://github.com/ioam/paramnb>`_) 
+or in Tk (`ParamTk <http://ioam.github.com/paramtk/>`_), both of which
+make it simple to provide a property sheet that automatically
+generates a set of widgets for viewing and editing an object's
+Parameters.
 
 
 Optional dynamic parameter values using `numbergen`
@@ -170,6 +181,16 @@ Release Notes
 
 Notable additions, or changes that may require users to alter code,
 are listed below.
+
+1.3.3 (2016/07)
+_______________
+
+* Added support for new (`ParamNB<https://github.com/ioam/paramnb>`_) ParamNB project
+* Added new parameter types Action, FileSelector, and ListSelector
+
+A full list of changes since the previous release is available 
+`on GitHub <https://github.com/ioam/param/compare/v1.3.2...v1.3.3>`_.
+
 
 1.3.2 (2015/04)
 _______________

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -25,6 +25,13 @@ from .parameterized import Parameterized, Parameter, String, \
 from .parameterized import logging_level # pyflakes:ignore (needed for eval)
 from .parameterized import shared_parameters # pyflakes:ignore (needed for eval)
 
+try: 
+   from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+except ImportError as e:
+    raise ImportError("Requires ordereddict package on Python 2.6")
+
 
 # Determine up-to-date version information, if possible, but with a
 # safe fallback to ensure that this file and parameterized.py are the
@@ -991,7 +998,7 @@ class ObjectSelector(Selector):
 
         (Returns the dictionary {object.name:object}.)
         """
-        return dict((obj.name if hasattr(obj,"name") \
+        return OrderedDict((obj.name if hasattr(obj,"name") \
                      else obj.__name__ if hasattr(obj,"__name__") \
                      else str(obj), obj) for obj in self.objects)
 
@@ -1043,7 +1050,7 @@ class ClassSelector(Selector):
         (see concrete_descendents()).
         """
         classes = concrete_descendents(self.class_)
-        d=dict((name,class_) for name,class_ in classes.items())
+        d=OrderedDict((name,class_) for name,class_ in classes.items())
         if self.allow_None:
             d['None']=None
         return d
@@ -1362,7 +1369,7 @@ def abbreviate_paths(pathspec,named_paths):
     from os.path import commonprefix, dirname, sep
 
     prefix = commonprefix([dirname(name)+sep for name in named_paths.keys()]+[pathspec])
-    return dict([(name[len(prefix):],path) for name,path in named_paths.items()])
+    return OrderedDict([(name[len(prefix):],path) for name,path in named_paths.items()])
 
 
 


### PR DESCRIPTION
Previously, options in a selection widget created from a Selector parameter would be in an arbitrary order, determined by the underlying Python dictionary type.  With this PR, the original supplied order of options should be preserved.

Under Python 2.6 requires installing the `ordereddict` package, but otherwise should support all the same Python versions as before.