### PR TITLE
Allow softbounds to be accessed like an attribute

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -573,6 +573,15 @@ class Number(Dynamic):
         super(Number,self).__set__(obj,val)
 
 
+    # Allow softbounds to be used like a normal attribute, as it 
+    # probably should have been already (not _softbounds)
+    @property
+    def softbounds(self): return self._softbounds
+
+    @softbounds.setter
+    def softbounds(self,value): self._softbounds = value
+
+
     def set_in_bounds(self,obj,val):
         """
         Set to the given value, but cropped to be within the legal bounds.


### PR DESCRIPTION
I can sort of see why, many years ago, we put the user-supplied softbounds for a numeric parameter into _softbounds and had people call get_soft_bounds instead, but I think now that Python has properties supported in every Python version we support, the design no longer makes much sense.  To make it slightly more reasonble, I've made softbounds be a property, essentially aliasing _softbounds as softbounds, so that no one needs to mess with _softbounds ever.