### PR TITLE
Check there's a working compiler; see #129.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,9 @@ except ImportError:
     from distutils.core import setup
 
 try:
+    # check we can compile on this machine
+    import cython; cython.inline("return 1;")
+    
     from Cython.Build import cythonize
     ext_modules = cythonize("param/*.py", exclude=['param/ipython.py'])
 except:


### PR DESCRIPTION
Before:
```
ceball@spheroid:~$ docker run --rm continuumio/anaconda:2.3.0 bash -c 'pip install param'
Collecting param
  Downloading param-1.4.1.zip (472kB)
Building wheels for collected packages: param
  Running setup.py bdist_wheel for param
  Complete output from command /opt/conda/bin/python -c "import setuptools;__file__='/tmp/pip-build-6WGJpP/param/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmprwtYGWpip-wheel-:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-2.7
  creating build/lib.linux-x86_64-2.7/param
  copying param/__init__.py -> build/lib.linux-x86_64-2.7/param
  copying param/parameterized.py -> build/lib.linux-x86_64-2.7/param
  copying param/ipython.py -> build/lib.linux-x86_64-2.7/param
  copying param/version.py -> build/lib.linux-x86_64-2.7/param
  creating build/lib.linux-x86_64-2.7/numbergen
  copying numbergen/__init__.py -> build/lib.linux-x86_64-2.7/numbergen
  running build_ext
  building 'param.__init__' extension
  creating build/temp.linux-x86_64-2.7
  creating build/temp.linux-x86_64-2.7/param
  gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/conda/include/python2.7 -c param/__init__.c -o build/temp.linux-x86_64-2.7/param/__init__.o
  unable to execute 'gcc': No such file or directory
  error: command 'gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for param
Failed to build param
Installing collected packages: param
  Running setup.py install for param
    Complete output from command /opt/conda/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip-build-6WGJpP/param/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-8Rv9Wg-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_py
    running build_ext
    building 'param.__init__' extension
    gcc -pthread -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/conda/include/python2.7 -c param/__init__.c -o build/temp.linux-x86_64-2.7/param/__init__.o
    unable to execute 'gcc': No such file or directory
    error: command 'gcc' failed with exit status 1
    
    ----------------------------------------
Command "/opt/conda/bin/python -c "import setuptools, tokenize;__file__='/tmp/pip-build-6WGJpP/param/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-8Rv9Wg-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-6WGJpP/param
```

After:
```
ceball@spheroid:~$ docker run --rm continuumio/anaconda:2.3.0 bash -c 'pip install https://github.com/ceball/param/archive/issue129-check_for_compiler.zip'
Collecting https://github.com/ceball/param/archive/issue129-check_for_compiler.zip
  Downloading https://github.com/ceball/param/archive/issue129-check_for_compiler.zip (76kB)
Building wheels for collected packages: param
  Running setup.py bdist_wheel for param
  Stored in directory: /.cache/pip/wheels/ad/fb/5d/aac87297ea7d5db5718976fd8beeed19ed7e6729ca42a4a466
Successfully built param
Installing collected packages: param
Successfully installed param-1.4.1
```

Do we currently have anywhere I can add a test like the one above?