### PR TITLE
Skip flake8 tests on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
 
 script:
   - nosetests --with-doctest --with-coverage --cover-package=param
-  - if [[ $TRAVIS_PYTHON_VERSION != 2.6]]; flake8 --statistics --exit-zero --ignore=E231 param numbergen
+  - if [[ $TRAVIS_PYTHON_VERSION =~ 2.6]]; flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ notifications:
 # no dependencies for py2.7+ (coveralls, ipython, flake8 only needed for testing)
 install:
   - pip install coveralls flake8
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict flake8==2.6; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
 script:
   - nosetests --with-doctest --with-coverage --cover-package=param
-  - if [[ $TRAVIS_PYTHON_VERSION ~= 2.6]]; then flake8 --statistics --exit-zero --ignore=E231 param numbergen; fi
+  - flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
-script: nosetests --with-doctest --with-coverage --cover-package=param && flake8 --statistics --exit-zero --ignore=E231 param numbergen
+script:
+  - nosetests --with-doctest --with-coverage --cover-package=param
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6]]; flake8 --statistics --exit-zero --ignore=E231 param numbergen
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
 
 script:
   - nosetests --with-doctest --with-coverage --cover-package=param
-  - if [[ $TRAVIS_PYTHON_VERSION != 2.6]]; then flake8 --statistics --exit-zero --ignore=E231 param numbergen; fi
+  - if [[ $TRAVIS_PYTHON_VERSION ~= 2.6]]; then flake8 --statistics --exit-zero --ignore=E231 param numbergen; fi
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ install:
 
 script:
   - nosetests --with-doctest --with-coverage --cover-package=param
-  - if [[ $TRAVIS_PYTHON_VERSION =~ 2.6]]; flake8 --statistics --exit-zero --ignore=E231 param numbergen
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.6]]; then flake8 --statistics --exit-zero --ignore=E231 param numbergen; fi
 
 after_success: coveralls


### PR DESCRIPTION
flake8 uses OrderedDict, not present in 2.6, so we should skip it.