### PR TITLE
Add value to the list of objects when ObjectSelector.check_on_set==False

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -990,14 +990,11 @@ class ObjectSelector(Selector):
             raise ValueError("%s not in Parameter %s's list of possible objects" \
                              %(val,attrib_name))
 
-# CBNOTE: I think it's not helpful to do a type check for the value of
-# an ObjectSelector. If we did such type checking, any user
-# of this Parameter would have to be sure to update the list of possible
-# objects before setting the Parameter's value. As it is, only users who care about the
-# correct list of objects being displayed need to update the list.
     def __set__(self,obj,val):
         if self.check_on_set:
             self._check_value(val,obj)
+        elif not (val in self.objects):
+            self.objects.append(val)
         super(ObjectSelector,self).__set__(obj,val)
 
 


### PR DESCRIPTION
param.ObjectSelector and its various subclasses (FileSelector, etc.) keep a list of objects that is used in two very different ways -- either as a fixed, immutable list of all meaningful possibilities (`check_on_set==True`), or as a helpful list of some things that can conveniently be selected in a GUI widget but which could happily include other items too (`check_on_set==False`).

Previously, if a value not in the list of objects was provided and `check_on_set==False`, param would set the value, but it would not change the list of objects.  This was causing problems for paramnb, because ipywidgets/traitlets enforced that the current value of the parameter *must* be on the list of widgets.  This PR ensures that any value explicitly set is put onto the list of allowed objects, so that such checks at the GUI level will stop failing.