### PR TITLE
Version fixes and improvements

### DIFF
--- a/param/version.py
+++ b/param/version.py
@@ -233,8 +233,10 @@ class Version(object):
         """
         if self.release is None: return 'None'
         release = '.'.join(str(el) for el in self.release)
-        if (self.commit_count == 0 and not self.dirty
-            and self.commit and  ("$Format" in self.commit)):
+
+        if (self.commit is not None) and  ("$Format" not in self.commit):
+            pass  # Concrete commit supplied - print full version string
+        elif (self.commit_count == 0 and not self.dirty):
             return release
 
         dirty_status = '-dirty' if self.dirty else ''

--- a/param/version.py
+++ b/param/version.py
@@ -242,9 +242,7 @@ class Version(object):
                                 self.commit, dirty_status)
 
     def __repr__(self):
-        return "Version(%r,%r,%r)" % (self.release,
-                                      self.fpath if self.fpath else None,
-                                      self.commit)
+        return str(self)
 
     def abbrev(self,dev_suffix=""):
         """

--- a/param/version.py
+++ b/param/version.py
@@ -233,7 +233,8 @@ class Version(object):
         """
         if self.release is None: return 'None'
         release = '.'.join(str(el) for el in self.release)
-        if self.commit_count == 0 and not self.dirty:
+        if (self.commit_count == 0 and not self.dirty
+            and self.commit and  ("$Format" in self.commit)):
             return release
 
         dirty_status = '-dirty' if self.dirty else ''

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -18,6 +18,10 @@ class TestVersion(unittest.TestCase):
         v101 = Version(release=(1,0,1), commit='fffffff')
         self.assertEqual(repr(v101), '1.0.1-0-gfffffff')
 
+    def test_repr_v101_10_commits(self):
+        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa')
+        self.assertEqual(repr(v101), '1.0.1-10-gaaaaaaa')
+
     def test_version_init_v101(self):
         Version(release=(1,0,1))
 

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -12,11 +12,11 @@ class TestVersion(unittest.TestCase):
 
     def test_repr_v1(self):
         v1 = Version(release=(1,0))
-        self.assertEqual(repr(v1), 'Version((1, 0),None,None)')
+        self.assertEqual(repr(v1), '1.0')
 
     def test_repr_v101(self):
-        v101 = Version(release=(1,0,1), commit='shortSHA')
-        self.assertEqual(repr(v101), "Version((1, 0, 1),None,'shortSHA')")
+        v101 = Version(release=(1,0,1), commit='fffffff')
+        self.assertEqual(repr(v101), '1.0.1-0-gfffffff')
 
     def test_version_init_v101(self):
         Version(release=(1,0,1))


### PR DESCRIPTION
Fixes a bug in ``param.Version`` when using pip to install from archive i.e:

```bash
pip install https://github.com/ioam/holoviews/archive/master.zip
```

The SHA was being set correctly via the ``'$Format'`` string but wasn't displaying appropriately (unless the source happened to also be in a dirty git repository).

In addition, users are used to looking at ``holoviews.__version__`` directly instead of ``str(holoviews.__version__)`` which is why I've made the ``repr`` match the string representation.