### PR TITLE
ObjectSelector lists possible objects on error

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1029,8 +1029,15 @@ class ObjectSelector(Selector):
                 attrib_name = self._attrib_name
             except AttributeError:
                 attrib_name = ""
-            raise ValueError("%s not in Parameter %s's list of possible objects" \
-                             %(val,attrib_name))
+
+            items = self.objects
+            limiter = ']'
+            if len(items) > 20:
+                items = items[:20]
+                limiter = ', ...]'
+            items = '[' + ', '.join(map(str, items)) + limiter
+            raise ValueError("%s not in Parameter %s's list of possible objects, "
+                             "valid options include %s"%(val,attrib_name, items))
 
     def _ensure_value_is_in_objects(self,val):
         """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1030,12 +1030,18 @@ class ObjectSelector(Selector):
             except AttributeError:
                 attrib_name = ""
 
-            items = self.objects
+            items = []
             limiter = ']'
-            if len(items) > 20:
-                items = items[:20]
-                limiter = ', ...]'
-            items = '[' + ', '.join(map(str, items)) + limiter
+            length = 0
+            for item in self.objects:
+                string = str(item)
+                length += len(string)
+                if length < 200:
+                    items.append(string)
+                else:
+                    limiter = ', ...]'
+                    break
+            items = '[' + ', '.join(items) + limiter
             raise ValueError("%s not in Parameter %s's list of possible objects, "
                              "valid options include %s"%(val,attrib_name, items))
 


### PR DESCRIPTION
The fact that ObjectSelector doesn't report what the valid values are has annoyed me and would help greatly with usability in holoviews. Is reporting the first 20 items too many?

Here's an example from HoloViews:

>ValueError: left not in Parameter xaxis's list of possible objects, valid options include [top, bottom, bare, top-bare, bottom-bare, None]
