### PR TITLE
Fixed ClassSelector error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 install:
   - pip install coveralls flake8
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ipython==1.0 ordereddict flake8==2.6; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install ipython==5.3; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then pip install ipython; fi
 
 script:

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1092,16 +1092,20 @@ class ClassSelector(Selector):
 
     def _check_value(self,val,obj=None):
         """val must be None, an instance of self.class_ if self.is_instance=True or a subclass of self_class if self.is_instance=False"""
+        if isinstance(self.class_, tuple):
+            class_name = ('(%s)' % ', '.join(cl.__name__ for cl in self.class_))
+        else:
+            class_name = self.class_.__name__
         if self.is_instance:
             if not (isinstance(val,self.class_)) and not (val is None and self.allow_None):
                 raise ValueError(
                     "Parameter '%s' value must be an instance of %s, not '%s'" %
-                    (self._attrib_name, self.class_.__name__, val))
+                    (self._attrib_name, class_name, val))
         else:
             if not (val is None and self.allow_None) and not (issubclass(val,self.class_)):
                 raise ValueError(
                     "Parameter '%s' must be a subclass of %s, not '%s'" %
-                    (val.__name__, self.class_.__name__, val.__class__.__name__))
+                    (val.__name__, class_name, val.__class__.__name__))
 
 
     def __set__(self,obj,val):

--- a/tests/testclassselector.py
+++ b/tests/testclassselector.py
@@ -1,0 +1,64 @@
+"""
+Unit test for ClassSelector parameters.
+"""
+
+from numbers import Number
+import unittest
+import param
+
+
+class TestClassSelectorParameters(unittest.TestCase):
+
+    def setUp(self):
+
+        class P(param.Parameterized):
+            e = param.ClassSelector(default=1,class_=int)
+            f = param.ClassSelector(default=int,class_=Number, is_instance=False)
+            g = param.ClassSelector(default=1,class_=(int,str))
+            h = param.ClassSelector(default=int,class_=(int,str), is_instance=False)
+
+        self.P = P
+
+    def test_single_class_instance_constructor(self):
+        p = self.P(e=6)
+        self.assertEqual(p.e, 6)
+
+    def test_single_class_instance_error(self):
+        exception = "Parameter 'e' value must be an instance of int, not 'a'"
+        with self.assertRaisesRegexp(ValueError, exception):
+            p = self.P(e='a')
+
+    def test_single_class_type_constructor(self):
+        p = self.P(f=float)
+        self.assertEqual(p.f, float)
+
+    def test_single_class_type_error(self):
+        exception = "Parameter 'str' must be a subclass of Number, not 'type'"
+        with self.assertRaisesRegexp(ValueError, exception):
+            p = self.P(f=str)
+
+    def test_multiple_class_instance_constructor1(self):
+        p = self.P(g=1)
+        self.assertEqual(p.g, 1)
+
+    def test_multiple_class_instance_constructor2(self):
+        p = self.P(g='A')
+        self.assertEqual(p.g, 'A')
+
+    def test_multiple_class_instance_error(self):
+        exception = "Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
+        with self.assertRaisesRegexp(ValueError, exception):
+            p = self.P(g=3.0)
+
+    def test_multiple_class_type_constructor1(self):
+        p = self.P(h=int)
+        self.assertEqual(p.h, int)
+
+    def test_multiple_class_type_constructor2(self):
+        p = self.P(h=str)
+        self.assertEqual(p.h, str)
+
+    def test_multiple_class_type_error(self):
+        exception = "Parameter 'float' must be a subclass of \(int, str\), not 'type'"
+        with self.assertRaisesRegexp(ValueError, exception):
+            p = self.P(h=float)

--- a/tests/testclassselector.py
+++ b/tests/testclassselector.py
@@ -2,8 +2,11 @@
 Unit test for ClassSelector parameters.
 """
 
-from numbers import Number
+import sys
 import unittest
+from numbers import Number
+
+from nose.plugins.skip import SkipTest
 import param
 
 
@@ -24,6 +27,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.e, 6)
 
     def test_single_class_instance_error(self):
+        if sys.version_info[:2] == (2, 6): raise SkipTest
         exception = "Parameter 'e' value must be an instance of int, not 'a'"
         with self.assertRaisesRegexp(ValueError, exception):
             p = self.P(e='a')
@@ -33,6 +37,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.f, float)
 
     def test_single_class_type_error(self):
+        if sys.version_info[:2] == (2, 6): raise SkipTest
         exception = "Parameter 'str' must be a subclass of Number, not 'type'"
         with self.assertRaisesRegexp(ValueError, exception):
             p = self.P(f=str)
@@ -46,6 +51,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.g, 'A')
 
     def test_multiple_class_instance_error(self):
+        if sys.version_info[:2] == (2, 6): raise SkipTest
         exception = "Parameter 'g' value must be an instance of \(int, str\), not '3.0'"
         with self.assertRaisesRegexp(ValueError, exception):
             p = self.P(g=3.0)
@@ -59,6 +65,7 @@ class TestClassSelectorParameters(unittest.TestCase):
         self.assertEqual(p.h, str)
 
     def test_multiple_class_type_error(self):
+        if sys.version_info[:2] == (2, 6): raise SkipTest
         exception = "Parameter 'float' must be a subclass of \(int, str\), not 'type'"
         with self.assertRaisesRegexp(ValueError, exception):
             p = self.P(h=float)


### PR DESCRIPTION
ClassSelector allows specifying multiple classes as a tuple because isinstance and issubclass support it. However the error handling code does not handle this condition correctly so you get a bad exception message. This PR fixes the exception message and adds unit tests. 