### PR TITLE
[WIP] Defined pre_set_hooks and post_set_hooks for Parameters

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -573,7 +573,7 @@ class Number(Dynamic):
       AB = Number(default=0.5, bounds=(None,10), softbounds=(0,1), doc='Distance from A to B.')
     """
 
-    __slots__ = ['bounds','_softbounds','inclusive_bounds','set_hook']
+    __slots__ = ['bounds','_softbounds','inclusive_bounds']
 
     def __init__(self,default=0.0,bounds=None,softbounds=None,inclusive_bounds=(True,True),**params):
         """
@@ -582,8 +582,6 @@ class Number(Dynamic):
         Non-dynamic default values are checked against the bounds.
         """
         super(Number,self).__init__(default=default,**params)
-
-        self.set_hook = identity_hook
         self.bounds = bounds
         self.inclusive_bounds = inclusive_bounds
         self._softbounds = softbounds
@@ -609,8 +607,6 @@ class Number(Dynamic):
         Also applies set_hook, providing support for conversions
         and transformations of the value.
         """
-        val = self.set_hook(obj,val)
-
         if not callable(val): self._check_value(val)
         super(Number,self).__set__(obj,val)
 


### PR DESCRIPTION
This PR is a prototype that replaces ``set_hook`` on ``Number`` with a more general system of pre- and post- setting hooks. This may be useful for things like linking streams or eventual unit support in param.

An example of what this might be useful for is shown in  ioam/holoviews#1740.

I'm not quite sure about the appropriate signatures for the hooks right now and this PR will probably need quite a bit of discussion before we are agreed on the appropriate approach.