### PR TITLE
Remove cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,14 @@ try:
 except ImportError:
     from distutils.core import setup
 
-try:
-    # check we can compile on this machine
-    import cython; cython.inline("return 1;")
-    
-    from Cython.Build import cythonize
-    ext_modules = cythonize("param/*.py", exclude=['param/ipython.py'])
-except:
-    ext_modules = []
 
-setup_args = {}
-
-setup_args.update(dict(
+setup_args = dict(
     name='param',
     version="1.5.1",
     description='Declarative Python programming using Parameters.',
     long_description=open('README.rst').read() if os.path.isfile('README.rst') else 'Consult README.rst',
     author= "IOAM",
     author_email= "developers@topographica.org",
-    ext_modules=ext_modules,
     maintainer="IOAM",
     maintainer_email="developers@topographica.org",
     platforms=['Windows', 'Mac OS X', 'Linux'],
@@ -45,7 +34,7 @@ setup_args.update(dict(
         "Natural Language :: English",
         "Topic :: Scientific/Engineering",
         "Topic :: Software Development :: Libraries"]
-))
+)
 
 
 


### PR DESCRIPTION
My opinion about #166. Note that the only people to have been getting cythonized param would be those installing from pip while also having cython and a functioning c compiler.

* Closes #161 (makes it redundant).
* Hopefully allows noarch conda packages, making #167 simpler.

If merged, I would open an issue about considering cythonizing once: 
* there's higher test coverage of param (e.g. resurrecting topographica's tests picked up a problem with cythonized param)
* there are performance tests

Meanwhile, it might be useful to cythonize param as part of testing (e.g. can be useful to catch certain classes of error/bad practice). We could maybe add a command/argument to setup.py to optionally cythonize param.