### PR TITLE
Added argument to param.Version to support dev versions

### DIFF
--- a/param/version.py
+++ b/param/version.py
@@ -217,6 +217,10 @@ class Version(object):
             # If there is any other error, return (release value still useful)
             return self
 
+        self._update_from_vcs(output)
+
+    def _update_from_vcs(output):
+        "Update state based on the VCS state e.g the output of git describe"
         split = output[1:].split('-')
         if 'dev' in split[0]:
             dev_split = split[0].split('dev')

--- a/param/version.py
+++ b/param/version.py
@@ -219,14 +219,14 @@ class Version(object):
 
         self._update_from_vcs(output)
 
-    def _update_from_vcs(output):
+    def _update_from_vcs(self, output):
         "Update state based on the VCS state e.g the output of git describe"
         split = output[1:].split('-')
         if 'dev' in split[0]:
             dev_split = split[0].split('dev')
             self.dev = int(dev_split[1])
             # Remove the dot if following pep440
-            split[0] = dev_split[0][1:] if self.pep440 else dev_split[0]
+            split[0] = dev_split[0][:-1] if self.pep440 else dev_split[0]
 
         self._release = tuple(int(el) for el in split[0].split('.'))
         self._commit_count = int(split[1])

--- a/param/version.py
+++ b/param/version.py
@@ -129,7 +129,7 @@ class Version(object):
     """
 
     def __init__(self, release=None, fpath=None, commit=None,
-                 reponame=None, dev=None, commit_count=0):
+                 reponame=None, dev=None, commit_count=0, pep440=True):
         """
         :release:      Release tuple (corresponding to the current VCS tag)
         :commit        Short SHA. Set to '$Format:%h$' for git archive support.
@@ -148,6 +148,7 @@ class Version(object):
         self._dirty = False
         self.reponame = reponame
         self.dev = dev
+        self.pep440 = pep440
 
     @property
     def release(self):
@@ -220,7 +221,8 @@ class Version(object):
         if 'dev' in split[0]:
             dev_split = split[0].split('dev')
             self.dev = int(dev_split[1])
-            split[0] = dev_split[0]
+            # Remove the dot if following pep440
+            split[0] = dev_split[0][1:] if self.pep440 else dev_split[0]
 
         self._release = tuple(int(el) for el in split[0].split('.'))
         self._commit_count = int(split[1])
@@ -243,7 +245,8 @@ class Version(object):
         """
         if self.release is None: return 'None'
         release = '.'.join(str(el) for el in self.release)
-        release = '%sdev%d' % (release, self.dev) if self.dev else release
+        release = ('%s%sdev%d' % (release, '.' if self.pep440 else '', self.dev)
+                   if self.dev else release)
 
         if (self._expected_commit is not None) and  ("$Format" not in self._expected_commit):
             pass  # Concrete commit supplied - print full version string

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -24,7 +24,13 @@ class TestVersion(unittest.TestCase):
         self.assertEqual(repr(v101), '1.0.1-10-gaaaaaaa')
 
     def test_repr_v101dev4_10_commits(self):
-        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa', dev=4)
+        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa',
+                       dev=4, pep440=True)
+        self.assertEqual(repr(v101), '1.0.1.dev4-10-gaaaaaaa')
+
+    def test_repr_v101dev4_10_commits_wo_pep440(self):
+        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa',
+                       dev=4, pep440=False)
         self.assertEqual(repr(v101), '1.0.1dev4-10-gaaaaaaa')
 
     def test_version_init_v101(self):
@@ -40,6 +46,10 @@ class TestVersion(unittest.TestCase):
 
     def test_version_str_v1dev3(self):
         v1 = Version(release=(1,0),dev=3)
+        self.assertEqual(str(v1), '1.0.dev3')
+
+    def test_version_str_v1dev3_wo_pep440(self):
+        v1 = Version(release=(1,0),dev=3, pep440=False)
         self.assertEqual(str(v1), '1.0dev3')
 
     def test_version_v1_dirty(self):

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -23,6 +23,10 @@ class TestVersion(unittest.TestCase):
         v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa')
         self.assertEqual(repr(v101), '1.0.1-10-gaaaaaaa')
 
+    def test_repr_v101dev4_10_commits(self):
+        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa', dev=4)
+        self.assertEqual(repr(v101), '1.0.1dev4-10-gaaaaaaa')
+
     def test_version_init_v101(self):
         Version(release=(1,0,1))
 
@@ -33,6 +37,10 @@ class TestVersion(unittest.TestCase):
     def test_version_str_v1(self):
         v1 = Version(release=(1,0))
         self.assertEqual(str(v1), '1.0')
+
+    def test_version_str_v1dev3(self):
+        v1 = Version(release=(1,0),dev=3)
+        self.assertEqual(str(v1), '1.0dev3')
 
     def test_version_v1_dirty(self):
         v1 = Version(release=(1,0))
@@ -72,10 +80,25 @@ class TestVersion(unittest.TestCase):
         v101 = Version(release=(1,0,1))
         self.assertEqual((v1 < v101), True)
 
+    def test_version_less_than_dev(self):
+        v101 = Version(release=(1,0,1))
+        v101dev2 = Version(release=(1,0,1), dev=2)
+        self.assertEqual((v101dev2 < v101), True)
+
+    def test_version_less_than_dev_number(self):
+        v101dev1 = Version(release=(1,0,1), dev=1)
+        v101dev2 = Version(release=(1,0,1), dev=2)
+        self.assertEqual((v101dev1 < v101dev2), True)
+
     def test_version_greater_than(self):
         v1 = Version(release=(1,0))
         v101 = Version(release=(1,0,1))
         self.assertEqual((v1 > v101), False)
+
+    def test_version_greater_than_dev(self):
+        v101 = Version(release=(1,0,1))
+        v102dev3 = Version(release=(1,0,2), dev=3)
+        self.assertEqual((v102dev3 > v101), True)
 
     def test_version_eq_v1(self):
         v1 = Version(release=(1,0))
@@ -84,6 +107,15 @@ class TestVersion(unittest.TestCase):
     def test_version_eq_v101(self):
         v101 = Version(release=(1,0,1))
         self.assertEqual(v101==v101, True)
+
+    def test_version_eq_v101_dev(self):
+        v101dev3 = Version(release=(1,0,1), dev=3)
+        self.assertEqual(v101dev3==v101dev3, True)
+
+    def test_version_neq_v101_dev(self):
+        v101dev2 = Version(release=(1,0,1), dev=2)
+        v101dev3 = Version(release=(1,0,1), dev=3)
+        self.assertEqual(v101dev2!=v101dev3, True)
 
     def test_version_neq(self):
         v1 = Version(release=(1,0))

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -81,6 +81,34 @@ class TestVersion(unittest.TestCase):
         v1 = Version(release=(1,0), commit='shortSHA')
         self.assertEqual(v1.commit, 'shortSHA')
 
+    #===========================================#
+    #  Update from VCS (currently git describe) #
+    #===========================================#
+
+    def test_version_simple_git_describe(self):
+        v105 = Version(release=(1,0,5))
+        v105._update_from_vcs('v1.0.5-42-gabcdefgh')
+        self.assertEqual(v105.release, (1,0,5))
+        self.assertEqual(v105.commit_count, 42)
+        self.assertEqual(v105.dev, None)
+        self.assertEqual(v105.commit, 'abcdefgh')
+
+    def test_version_dev_pep440_git_describe(self):
+        v105 = Version(release=(1,0,5), dev=4, pep440=True)
+        v105._update_from_vcs('v1.0.6.dev4-42-gabcdefgh')
+        self.assertEqual(v105.release, (1,0,6))
+        self.assertEqual(v105.commit_count, 42)
+        self.assertEqual(v105.dev, 4)
+        self.assertEqual(v105.commit, 'abcdefgh')
+
+    def test_version_dev_wo_pep440_git_describe(self):
+        v105 = Version(release=(1,0,5), dev=4, pep440=False)
+        v105._update_from_vcs('v1.0.6dev4-42-gabcdefgh')
+        self.assertEqual(v105.release, (1,0,6))
+        self.assertEqual(v105.commit_count, 42)
+        self.assertEqual(v105.dev, 4)
+        self.assertEqual(v105.commit, 'abcdefgh')
+
     #===========================#
     #  Comparisons and equality #
     #===========================#

--- a/tests/testversion.py
+++ b/tests/testversion.py
@@ -24,14 +24,8 @@ class TestVersion(unittest.TestCase):
         self.assertEqual(repr(v101), '1.0.1-10-gaaaaaaa')
 
     def test_repr_v101dev4_10_commits(self):
-        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa',
-                       dev=4, pep440=True)
+        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa', dev=4)
         self.assertEqual(repr(v101), '1.0.1.dev4-10-gaaaaaaa')
-
-    def test_repr_v101dev4_10_commits_wo_pep440(self):
-        v101 = Version(release=(1,0,1), commit_count=10, commit='aaaaaaa',
-                       dev=4, pep440=False)
-        self.assertEqual(repr(v101), '1.0.1dev4-10-gaaaaaaa')
 
     def test_version_init_v101(self):
         Version(release=(1,0,1))
@@ -47,10 +41,6 @@ class TestVersion(unittest.TestCase):
     def test_version_str_v1dev3(self):
         v1 = Version(release=(1,0),dev=3)
         self.assertEqual(str(v1), '1.0.dev3')
-
-    def test_version_str_v1dev3_wo_pep440(self):
-        v1 = Version(release=(1,0),dev=3, pep440=False)
-        self.assertEqual(str(v1), '1.0dev3')
 
     def test_version_v1_dirty(self):
         v1 = Version(release=(1,0))
@@ -94,7 +84,7 @@ class TestVersion(unittest.TestCase):
         self.assertEqual(v105.commit, 'abcdefgh')
 
     def test_version_dev_pep440_git_describe(self):
-        v105 = Version(release=(1,0,5), dev=4, pep440=True)
+        v105 = Version(release=(1,0,5), dev=4)
         v105._update_from_vcs('v1.0.6.dev4-42-gabcdefgh')
         self.assertEqual(v105.release, (1,0,6))
         self.assertEqual(v105.commit_count, 42)
@@ -102,7 +92,7 @@ class TestVersion(unittest.TestCase):
         self.assertEqual(v105.commit, 'abcdefgh')
 
     def test_version_dev_wo_pep440_git_describe(self):
-        v105 = Version(release=(1,0,5), dev=4, pep440=False)
+        v105 = Version(release=(1,0,5), dev=4)
         v105._update_from_vcs('v1.0.6dev4-42-gabcdefgh')
         self.assertEqual(v105.release, (1,0,6))
         self.assertEqual(v105.commit_count, 42)


### PR DESCRIPTION
Added ``dev`` argument that allows dev versions to be handled like regular release versions. I'm happy to add more unit tests to make sure everyone is satisfied with this addition.