### PR TITLE
Upload "latest master" conda package to pyviz/label/dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
   - lint
   - test
   - name: conda_package
-    if: branch = master AND type != pull_request
+#    if: branch = master AND type != pull_request
   - name: pypi_package
     if: branch = master AND type != pull_request
 
@@ -73,7 +73,7 @@ jobs:
         - conda install "conda-build=3.0.25" anaconda-client
       script:
         - conda build conda.recipe/
-	- anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
+        - anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
 
     - <<: *default
       stage: pypi_package
@@ -89,4 +89,3 @@ jobs:
         user: ceball
         password:
           secure: odJx1tSnIIyVZjj+dB2bZDGHroLGvvSjy0OIyKJtyosZ0s3xgYNrC49SPgGJacp7uM+hIL8Hw/FuGTKOAGwQWmJIkznQcT7NzPCyOgAArH+0k5+EDl3Y0+MrSsMRpW6FurOcPFyJHl4zjfuFP/0ORDwZqljQ4SCqytvo/gaJ1JgCMi/jFafdvKrpSZBaK/Wfm0zilPN1QZAaQfGG+Ej5kG9BjybEszyZIqSe6FccAZLr62ko0necXx/DG2rrfxVtOPEFlYctwxngr9og9QjVY8j2zFyIHolxDUR7Iv2ADR7MCjtBJWlBek3S+rFe3dxGg3TbcnrmuV3tL1yaObMOfCCYT0pI/0lq08q4OgJQFW41eGailZ9lRNxQsPeFTvvTmYmZA8mCD/spD5z5pJmehny+rSW2rmFonUq15GG/bHnV48FrNyq6rA+lFLBSzVHjFsp+ZCWAHxQTj/zkqMO3ReBt7B+2Zu+Fkj8fsnUqWqoNEoBPJx5jTR4lfgg5TQJ9FUiLmoB7LG+H8BQL9ylY7XG00MyyAN89YLqZTg2CI1mKeCWW2CB5kXMc39o1qDOm0QsCJPATfle5bNPoKDg5Gtod9U3eFc+c8/ynOSrZzP8IGTK5uMsFuhpMQ/DAKJqLmMn8H712zwVY4znza9NJMDQWgNMTDr7+w8JFm0hiqO8=
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
         - conda install "conda-build=3.0.25" anaconda-client
       script:
         - export VERSIONHACK=`python -c "import subprocess;desc=subprocess.check_output(['git','describe']).decode('utf8');v,commits=desc.split('-')[0:2];newv=[int(x) for x in v[1::].split('.')];newv[-1]+=1;print('.'.join(str(x) for x in newv)+'.dev'+commits)"`
-	- conda build conda.recipe/
+        - conda build conda.recipe/
         - anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
 
     - <<: *default

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
   - lint
   - test
   - name: conda_package
-    if: branch = master AND type != pull_request
+#    if: branch = master AND type != pull_request
   - name: pypi_package
     if: branch = master AND type != pull_request
 
@@ -72,7 +72,7 @@ jobs:
         - conda update conda
         - conda install "conda-build=3.0.25" anaconda-client
       script:
-        - conda build --token $CONDA_UPLOAD_TOKEN --user cball conda.recipe/
+        - conda build --token $CONDA_UPLOAD_TOKEN --user pyviz conda.recipe/
 
     - <<: *default
       stage: pypi_package

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
   - lint
   - test
   - name: conda_package
-    if: branch = master AND type != pull_request
+#    if: branch = master AND type != pull_request
   - name: pypi_package
     if: branch = master AND type != pull_request
 
@@ -72,7 +72,7 @@ jobs:
         - conda update conda
         - conda install "conda-build=3.0.25" anaconda-client
       script:
-        - conda build conda.recipe/
+        - VERSIONHACK=`python -c "import subprocess;desc=subprocess.check_output(['git','describe']).decode('utf8');v,commits=desc.split('-')[0:2];newv=[int(x) for x in v[1::].split('.')];newv[-1]+=1;print('.'.join(str(x) for x in newv)+'.dev'+commits)"` conda build conda.recipe/ --output
         - anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
 
     - <<: *default

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ stages:
   - lint
   - test
   - name: conda_package
-#    if: branch = master AND type != pull_request
+    if: branch = master AND type != pull_request
   - name: pypi_package
     if: branch = master AND type != pull_request
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,8 @@ jobs:
         - conda update conda
         - conda install "conda-build=3.0.25" anaconda-client
       script:
-        - VERSIONHACK=`python -c "import subprocess;desc=subprocess.check_output(['git','describe']).decode('utf8');v,commits=desc.split('-')[0:2];newv=[int(x) for x in v[1::].split('.')];newv[-1]+=1;print('.'.join(str(x) for x in newv)+'.dev'+commits)"` conda build conda.recipe/ --output
+        - export VERSIONHACK=`python -c "import subprocess;desc=subprocess.check_output(['git','describe']).decode('utf8');v,commits=desc.split('-')[0:2];newv=[int(x) for x in v[1::].split('.')];newv[-1]+=1;print('.'.join(str(x) for x in newv)+'.dev'+commits)"`
+	- conda build conda.recipe/
         - anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
 
     - <<: *default

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,8 @@ jobs:
         - conda update conda
         - conda install "conda-build=3.0.25" anaconda-client
       script:
-        - conda build --token $CONDA_UPLOAD_TOKEN --user pyviz conda.recipe/
+        - conda build conda.recipe/
+	- anaconda --token $CONDA_UPLOAD_TOKEN upload --user pyviz --label dev `conda build --output conda.recipe`
 
     - <<: *default
       stage: pypi_package

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: param
-  version: {{environ['GIT_DESCRIBE_TAG'].lstrip('v')}}.post{{GIT_DESCRIBE_NUMBER}}.dev+{{GIT_DESCRIBE_HASH}}
+  version: {{ os.environ.get("VERSIONHACK") }}
 
 source:
   path: ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: param
-  version: {{environ['GIT_DESCRIBE_TAG'].lstrip('v').split('.dev')[0]}}.dev{{GIT_BUILD_STR }}
+  version: {{environ['GIT_DESCRIBE_TAG'].lstrip('v')}}.post{{GIT_DESCRIBE_NUMBER}}.dev+{{GIT_DESCRIBE_HASH}}
 
 source:
   path: ..

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -143,7 +143,7 @@ Official releases of Param are available on
 ``conda install -c ioam param``, ``pip install --user param``, or 
 ``pip install param``.
 
-The very latest changes can be obtained via ``conda install -c cball
+The very latest changes can be obtained via ``conda install -c pyviz
 param`` or ``pip install
 https://github.com/ioam/param/archive/master.zip``.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -143,7 +143,7 @@ Official releases of Param are available on
 ``conda install -c ioam param``, ``pip install --user param``, or 
 ``pip install param``.
 
-The very latest changes can be obtained via ``conda install -c pyviz
+The very latest changes can be obtained via ``conda install -c pyviz/label/dev
 param`` or ``pip install
 https://github.com/ioam/param/archive/master.zip``.
 


### PR DESCRIPTION
When merged, will make a conda package appear at pyviz/label/dev for any commit to master. The conda package will have the version style shown below:

<img width="1386" alt="screen shot 2018-01-11 at 5 31 06 pm" src="https://user-images.githubusercontent.com/1929/34838237-47c2384c-f6f5-11e7-84ac-45ecea69f138.png">

Note: 
  * before merging, should delete the test packages
  * needs to be squash merged
  * the contained python package `__version__` will be what's hardcoded in the param source code i.e. the most recent release, I think (something that could be addressed in the future)

Another note: I don't have a strong opinion about the version format we use. Also, various similar forms seems to be accepted and 'canonicalized':
```
>>> from packaging.version import Version as V
>>> V('1.2.3.post1.dev0')
<Version('1.2.3.post1.dev0')>
>>> V('1.2.3.post1.dev')
<Version('1.2.3.post1.dev0')>
>>> V('v1.2.3.post1.dev')
<Version('1.2.3.post1.dev0')>
>>> V('v1.2.3.post1dev')
<Version('1.2.3.post1.dev0')>
```