### PR TITLE
Add python 3.7 to linux test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,6 @@ jobs:
       env: TOX_ENV=py35
 
     - <<: *default
-      python: 3.5
-      env: TOX_ENV=py35
-
-    - <<: *default
       python: 3.4
       env: TOX_ENV=py34
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,14 @@ jobs:
         - tox -e $TOX_ENV
 
     - <<: *default
+      python: 3.7-dev
+      env: TOX_ENV=py37
+
+    - <<: *default
+      python: 3.5
+      env: TOX_ENV=py35
+
+    - <<: *default
       python: 3.5
       env: TOX_ENV=py35
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36,py35,py34,py27,pypy,
+    py37,py36,py35,py34,py27,pypy,
     {py27,py36}-flakes,
     {py27,py36}-with_numpy,
     {py27,py36}-with_ipython


### PR DESCRIPTION
Python 3.7 is scheduled for release in June.

This PR doesn't have to be merged - we could just update this PR from time to time.