### PR TITLE
Added regular expression to 'String' Parameter

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -546,7 +546,7 @@ class Number(Dynamic):
     When not being dynamically generated, bounds are checked when a
     Number is created or set. Using a default value outside the hard
     bounds, or one that is not numeric, results in an exception. When
-    being dynamically generated, bounds are checked when a the value
+    being dynamically generated, bounds are checked when the value
     of a Number is requested. A generated value that is not numeric,
     or is outside the hard bounds, results in an exception.
 
@@ -563,7 +563,7 @@ class Number(Dynamic):
     allows, for instance, a GUI to know what values to display on
     sliders for the Number.
 
-    Example of creating a Number::
+    Example of creating a Number:
       AB = Number(default=0.5, bounds=(None,10), softbounds=(0,1), doc='Distance from A to B.')
     """
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -519,24 +519,36 @@ class Parameter(object):
 # Define one particular type of Parameter that is used in this file
 class String(Parameter):
     """
-    A simple String parameter.
+    A String Parameter, with a default value and optional regular expression.
+
+    Example of creating a String:
+      ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+      IP = String(default='0.0.0.0', regexp=ip_regexp, doc='An IP address.')
     """
+
+    __slots__ = ['regexp']
 
     basestring = basestring if sys.version_info[0]==2 else str # noqa: it is defined
 
-    def __init__(self, default="", allow_None=False, **kwargs):
+    def __init__(self, default="", regexp=None, allow_None=False, **kwargs):
         super(String, self).__init__(default=default, allow_None=allow_None, **kwargs)
-        self._check_value(default)
+        self.regexp = regexp
         self.allow_None = (default is None or allow_None)
+        self._check_value(default)
 
     def _check_value(self,val):
-        if not isinstance(val, self.basestring) and not (self.allow_None and val is None):
+        if self.allow_None and val is None:
+            return
+
+        if not isinstance(val, self.basestring):
             raise ValueError("String '%s' only takes a string value."%self._attrib_name)
+
+        if self.regexp is not None and re.match(self.regexp, val) is None:
+            raise ValueError("String '%s' does not match regular expression."%self._attrib_name)
 
     def __set__(self,obj,val):
         self._check_value(val)
         super(String,self).__set__(obj,val)
-
 
 
 class shared_parameters(object):

--- a/tests/API0/teststringparam.py
+++ b/tests/API0/teststringparam.py
@@ -6,15 +6,52 @@ import unittest
 
 import param
 
-# TODO: very incomplete!
+
+ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(unittest.TestCase):
 
-    def test_default_none(self):
+    def test_regexp_ok(self):
         class A(param.Parameterized):
-            s = param.String(None)
+            s = param.String('0.0.0.0', ip_regexp)
 
         a = A()
-        a.s = "hello"
-        a.s = None # because allow_None should be True with default of None
+        a.s = '123.123.0.1'
+
+    def test_reject_none(self):
+        class A(param.Parameterized):
+            s = param.String('0.0.0.0', ip_regexp)
+
+        a = A()
+
+        exception = "String 's' only takes a string value."
+        with self.assertRaisesRegexp(ValueError, exception):
+            a.s = None  # because allow_None should be False
+
+    def test_default_none(self):
+        class A(param.Parameterized):
+            s = param.String(None, ip_regexp)
+
+        a = A()
+        a.s = '123.123.0.1'
+        a.s = None  # because allow_None should be True with default of None
+
+    def test_regexp_incorrect(self):
+
+        class A(param.Parameterized):
+            s = param.String('0.0.0.0', regexp=ip_regexp)
+
+        a = A()
+
+        exception = "String 's' does not match regular expression."
+        with self.assertRaisesRegexp(ValueError, exception):
+            a.s = '123.123.0.256'
+
+    def test_regexp_incorrect_default(self):
+
+        exception = "String 'None' does not match regular expression."
+        with self.assertRaisesRegexp(ValueError, exception):
+            class A(param.Parameterized):
+                s = param.String(regexp=ip_regexp)  # default value '' does not match regular expression
+
 

--- a/tests/API1/teststringparam.py
+++ b/tests/API1/teststringparam.py
@@ -2,17 +2,55 @@
 Unit test for String parameters
 """
 from . import API1TestCase
+
 import param
 
-# TODO: very incomplete!
+
+ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(API1TestCase):
 
-    def test_default_none(self):
+    def test_regexp_ok(self):
         class A(param.Parameterized):
-            s = param.String(None)
+            s = param.String('0.0.0.0', ip_regexp)
 
         a = A()
-        a.s = "hello"
-        a.s = None # because allow_None should be True with default of None
+        a.s = '123.123.0.1'
+
+    def test_reject_none(self):
+        class A(param.Parameterized):
+            s = param.String('0.0.0.0', ip_regexp)
+
+        a = A()
+
+        exception = "String 's' only takes a string value."
+        with self.assertRaisesRegexp(ValueError, exception):
+            a.s = None  # because allow_None should be False
+
+    def test_default_none(self):
+        class A(param.Parameterized):
+            s = param.String(None, ip_regexp)
+
+        a = A()
+        a.s = '123.123.0.1'
+        a.s = None  # because allow_None should be True with default of None
+
+    def test_regexp_incorrect(self):
+
+        class A(param.Parameterized):
+            s = param.String('0.0.0.0', regexp=ip_regexp)
+
+        a = A()
+
+        exception = "String 's' does not match regular expression."
+        with self.assertRaisesRegexp(ValueError, exception):
+            a.s = '123.123.0.256'
+
+    def test_regexp_incorrect_default(self):
+
+        exception = "String 'None' does not match regular expression."
+        with self.assertRaisesRegexp(ValueError, exception):
+            class A(param.Parameterized):
+                s = param.String(regexp=ip_regexp)  # default value '' does not match regular expression
+
 


### PR DESCRIPTION
Hello,

As mentioned in issue #240, i have added regular expression matching to the String Parameter sub-class.
I also added relative API0 and API1 tests, but was only able to run the API0 tests.

(In addition i corrected typos in the Number Parameter sub-class)

param is a great package so I was happy to add this small contribution

Best, 
Thomas Deneux