### PR TITLE
'regex string' fixups

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -519,22 +519,26 @@ class Parameter(object):
 # Define one particular type of Parameter that is used in this file
 class String(Parameter):
     """
-    A String Parameter, with a default value and optional regular expression.
+    A String Parameter, with a default value and optional regular expression (regex) matching.
 
-    Example of creating a String::
+    Example of using a regex to implement IPv4 address matching::
 
-      ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
-      IP = String(default='0.0.0.0', regexp=ip_regexp, doc='An IP address.')
+      class IPAddress(String):
+        '''IPv4 address as a string (dotted decimal notation)'''
+       def __init__(self, default="0.0.0.0", allow_None=False, **kwargs):
+           ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+           super(IPAddress, self).__init__(default=default, regex=ip_regex, **kwargs)
+
 
     """
 
-    __slots__ = ['regexp']
+    __slots__ = ['regex']
 
     basestring = basestring if sys.version_info[0]==2 else str # noqa: it is defined
 
-    def __init__(self, default="", regexp=None, allow_None=False, **kwargs):
+    def __init__(self, default="", regex=None, allow_None=False, **kwargs):
         super(String, self).__init__(default=default, allow_None=allow_None, **kwargs)
-        self.regexp = regexp
+        self.regex = regex
         self.allow_None = (default is None or allow_None)
         self._check_value(default)
 
@@ -545,8 +549,8 @@ class String(Parameter):
         if not isinstance(val, self.basestring):
             raise ValueError("String '%s' only takes a string value."%self._attrib_name)
 
-        if self.regexp is not None and re.match(self.regexp, val) is None:
-            raise ValueError("String '%s' does not match regular expression."%self._attrib_name)
+        if self.regex is not None and re.match(self.regex, val) is None:
+            raise ValueError("String '%s': '%s' does not match regex '%s'."%(self._attrib_name,val,self.regex))
 
     def __set__(self,obj,val):
         self._check_value(val)

--- a/tests/API0/teststringparam.py
+++ b/tests/API0/teststringparam.py
@@ -25,7 +25,7 @@ class TestStringParameters(unittest.TestCase):
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
@@ -44,13 +44,13 @@ class TestStringParameters(unittest.TestCase):
         a = A()
 
         exception = "String 's': '123.123.0.256' does not match regex"
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             a.s = '123.123.0.256'
 
     def test_regex_incorrect_default(self):
 
         exception = "String 'None': '' does not match regex"
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             class A(param.Parameterized):
                 s = param.String(regex=ip_regex)  # default value '' does not match regular expression
 

--- a/tests/API0/teststringparam.py
+++ b/tests/API0/teststringparam.py
@@ -7,51 +7,51 @@ import unittest
 import param
 
 
-ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(unittest.TestCase):
 
-    def test_regexp_ok(self):
+    def test_regex_ok(self):
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', ip_regexp)
+            s = param.String('0.0.0.0', ip_regex)
 
         a = A()
         a.s = '123.123.0.1'
 
     def test_reject_none(self):
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', ip_regexp)
+            s = param.String('0.0.0.0', ip_regex)
 
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
         class A(param.Parameterized):
-            s = param.String(None, ip_regexp)
+            s = param.String(None, ip_regex)
 
         a = A()
         a.s = '123.123.0.1'
         a.s = None  # because allow_None should be True with default of None
 
-    def test_regexp_incorrect(self):
+    def test_regex_incorrect(self):
 
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', regexp=ip_regexp)
+            s = param.String('0.0.0.0', regex=ip_regex)
 
         a = A()
 
-        exception = "String 's' does not match regular expression."
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = "String 's': '123.123.0.256' does not match regex"
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = '123.123.0.256'
 
-    def test_regexp_incorrect_default(self):
+    def test_regex_incorrect_default(self):
 
-        exception = "String 'None' does not match regular expression."
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = "String 'None': '' does not match regex"
+        with self.assertRaisesRegex(ValueError, exception):
             class A(param.Parameterized):
-                s = param.String(regexp=ip_regexp)  # default value '' does not match regular expression
+                s = param.String(regex=ip_regex)  # default value '' does not match regular expression
 
 

--- a/tests/API1/teststringparam.py
+++ b/tests/API1/teststringparam.py
@@ -24,7 +24,7 @@ class TestStringParameters(API1TestCase):
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
@@ -43,13 +43,13 @@ class TestStringParameters(API1TestCase):
         a = A()
 
         exception = "String 's': '123.123.0.256' does not match regex"  
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             a.s = '123.123.0.256'
 
     def test_regex_incorrect_default(self):
 
         exception = "String 'None': '' does not match regex"
-        with self.assertRaisesRegex(ValueError, exception):
+        with self.assertRaisesRegexp(ValueError, exception):
             class A(param.Parameterized):
                 s = param.String(regex=ip_regex)  # default value '' does not match regular expression
 

--- a/tests/API1/teststringparam.py
+++ b/tests/API1/teststringparam.py
@@ -6,51 +6,51 @@ from . import API1TestCase
 import param
 
 
-ip_regexp = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
+ip_regex = '^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$'
 
 class TestStringParameters(API1TestCase):
 
-    def test_regexp_ok(self):
+    def test_regex_ok(self):
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', ip_regexp)
+            s = param.String('0.0.0.0', ip_regex)
 
         a = A()
         a.s = '123.123.0.1'
 
     def test_reject_none(self):
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', ip_regexp)
+            s = param.String('0.0.0.0', ip_regex)
 
         a = A()
 
         exception = "String 's' only takes a string value."
-        with self.assertRaisesRegexp(ValueError, exception):
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = None  # because allow_None should be False
 
     def test_default_none(self):
         class A(param.Parameterized):
-            s = param.String(None, ip_regexp)
+            s = param.String(None, ip_regex)
 
         a = A()
         a.s = '123.123.0.1'
         a.s = None  # because allow_None should be True with default of None
 
-    def test_regexp_incorrect(self):
+    def test_regex_incorrect(self):
 
         class A(param.Parameterized):
-            s = param.String('0.0.0.0', regexp=ip_regexp)
+            s = param.String('0.0.0.0', regex=ip_regex)
 
         a = A()
 
-        exception = "String 's' does not match regular expression."
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = "String 's': '123.123.0.256' does not match regex"  
+        with self.assertRaisesRegex(ValueError, exception):
             a.s = '123.123.0.256'
 
-    def test_regexp_incorrect_default(self):
+    def test_regex_incorrect_default(self):
 
-        exception = "String 'None' does not match regular expression."
-        with self.assertRaisesRegexp(ValueError, exception):
+        exception = "String 'None': '' does not match regex"
+        with self.assertRaisesRegex(ValueError, exception):
             class A(param.Parameterized):
-                s = param.String(regexp=ip_regexp)  # default value '' does not match regular expression
+                s = param.String(regex=ip_regex)  # default value '' does not match regular expression
 
 


### PR DESCRIPTION
* Renamed regexp to regex (matching python docs, and regexp in method names is deprecated in unittest2/python3). 
* Altered regex example to encourage creation of meaningful Parameter subclasses.
* Added string and regex values to the failure-to-match error message.