### PR TITLE
Dependencies: support more pythons and begin storing dependency info in more convenient way

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -915,6 +915,9 @@ class Composite(Parameter):
     attributes.
     """
 
+    # Note: objtype is same as _owner, but objtype left for backwards
+    # compatibility (I think it's used in places to detect composite
+    # parameter)
     __slots__=['attribs','objtype']
 
     def __init__(self,attribs=None,**kw):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1281,6 +1281,7 @@ class ParameterizedMetaclass(type):
         for param_name,param in parameters:
             mcs._initialize_parameter(param_name,param)
 
+        # retrieve depends info from methods and store more conveniently
         dependers = [(n,m._dinfo) for (n,m) in dict_.items()
                      if hasattr(m,'_dinfo')]
 


### PR DESCRIPTION
* Support python 2.7 and python3 <3.6
* Keep list of watched methods on class (avoids having to search all attributes at instantiation time)