### PR TITLE
Added param_union, unit tests

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -103,14 +103,19 @@ def named_objs(objlist):
     return objs
 
 
-def param_union(*parameterizeds, warn=True):
+def param_union(*parameterizeds, **kwargs):
     """
     Given a set of Parameterized objects, returns a dictionary
     with the union of all param name,value pairs across them.
-    If warn is True, warns if the same parameter has been given
-    multiple values; otherwise uses the last value
+    If warn is True (default), warns if the same parameter has
+    been given multiple values; otherwise uses the last value
     """
-    d = {}
+    warn = kwargs.pop('warn', True)
+    if len(kwargs):
+        raise TypeError(
+            "param_union() got an unexpected keyword argument '{}'".format(
+                kwargs.popitem()[0]))
+    d = dict()
     for o in parameterizeds:
         for k, p in o.param.params().items():
             if k != 'name':

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -21,6 +21,7 @@ import sys
 import glob
 import re
 import datetime as dt
+import warnings
 
 from .parameterized import Parameterized, Parameter, String, \
      descendents, ParameterizedFunction, ParamOverrides
@@ -101,6 +102,22 @@ def named_objs(objlist):
         objs[k] = obj
     return objs
 
+
+def param_union(*parameterizeds, warn=True):
+    """
+    Given a set of Parameterized objects, returns a dictionary
+    with the union of all param name,value pairs across them.
+    If warn is True, warns if the same parameter has been given
+    multiple values; otherwise uses the last value
+    """
+    d = {}
+    for o in parameterizeds:
+        for k, p in o.param.params().items():
+            if k != 'name':
+                if k in d and warn:
+                    warnings.warn("overwriting parameter {}".format(k))
+                d[k] = getattr(o, k)
+    return d
 
 
 class Infinity(object):

--- a/tests/API1/testparamunion.py
+++ b/tests/API1/testparamunion.py
@@ -40,6 +40,10 @@ class TestParamUnion(API1TestCase):
             self.assertFalse(wlist)
             A(**param.param_union(a, a))
             self.assertTrue(wlist)
-            wlist.clear()
+            wlist.pop()
             A(**param.param_union(a, a, warn=False))
             self.assertFalse(wlist)
+
+    def test_param_union_raises_on_unexpected_kwarg(self):
+        with self.assertRaises(TypeError):
+            param.param_union(dumbdumbface=True)

--- a/tests/API1/testparamunion.py
+++ b/tests/API1/testparamunion.py
@@ -1,0 +1,45 @@
+"""
+UnitTest for param_union helper
+"""
+
+import warnings
+
+import param
+from . import API1TestCase
+
+class TestParamUnion(API1TestCase):
+
+    def test_param_union_values(self):
+        class A(param.Parameterized):
+            a = param.Number(1)
+        class B(param.Parameterized):
+            b = param.Number(2)
+        class C(A, B):
+            pass
+        a = A()
+        a.a = 10
+        b = B()
+        b.b = 5
+        c_1 = C(**param.param_union(a))
+        self.assertTrue(c_1.a == 10 and c_1.b == 2)
+        c_2 = C(**param.param_union(b))
+        self.assertTrue(c_2.a == 1 and c_2.b == 5)
+        c_3 = C(**param.param_union(a, b))
+        self.assertTrue(c_3.a == 10 and c_3.b == 5)
+        c_4 = C(**param.param_union())
+        self.assertTrue(c_4.a == 1 and c_4.b == 2)
+
+    def test_param_union_warnings(self):
+        class A(param.Parameterized):
+            a = param.Number(1)
+        a = A()
+        with warnings.catch_warnings(record=True) as wlist:
+            A(**param.param_union(a))
+            self.assertFalse(wlist)
+            A(**param.param_union())
+            self.assertFalse(wlist)
+            A(**param.param_union(a, a))
+            self.assertTrue(wlist)
+            wlist.clear()
+            A(**param.param_union(a, a, warn=False))
+            self.assertFalse(wlist)


### PR DESCRIPTION
This is the results of the discussion from #251. A helper function ``param_union`` was added to ``param/__init__.py`` that allows new parameter objects to be easily initialized from older ones. The behaviour is mostly the same to that discussed, except

- Supports API 1
- Overwrites the value instead of preserving the first

Also added some basic unit tests.