### PR TITLE
Allow ObjectSelector classes to accept a dictionary with names

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -989,7 +989,9 @@ class ObjectSelector(Selector):
     The list of objects can be supplied as a list (appropriate for
     selecting among a set of strings, or among a set of objects with a
     "name" parameter), or as a (preferably ordered) dictionary from
-    names to objects.
+    names to objects.  If a dictionary is supplied, the objects
+    will need to be hashable so that their names can be looked
+    up from the object value.
     """
 
     __slots__ = ['objects','compute_default_fn','check_on_set','names']

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -1002,7 +1002,7 @@ class ObjectSelector(Selector):
             objects = []
         if isinstance(objects, collections.Mapping):
             self.names = objects
-            self.objects = objects.values()
+            self.objects = list(objects.values())
         else:
             self.names = None
             self.objects = objects

--- a/tests/API1/testobjectselector.py
+++ b/tests/API1/testobjectselector.py
@@ -7,6 +7,7 @@ testEnumerationParameter.txt
 
 import param
 from . import API1TestCase
+from collections import OrderedDict
 
 class TestObjectSelectorParameters(API1TestCase):
 
@@ -18,12 +19,23 @@ class TestObjectSelectorParameters(API1TestCase):
             h = param.ObjectSelector(default=None)
             g = param.ObjectSelector(default=None,objects=[7,8])
             i = param.ObjectSelector(default=7,objects=[9],check_on_set=False)
+            s = param.ObjectSelector(default=3,objects=OrderedDict(one=1,two=2,three=3))
 
         self.P = P
 
     def test_set_object_constructor(self):
         p = self.P(e=6)
         self.assertEqual(p.e, 6)
+
+    def test_get_range_list(self):
+        r = self.P.param.params("g").get_range()
+        self.assertEqual(r['7'],7)
+        self.assertEqual(r['8'],8)
+
+    def test_get_range_dict(self):
+        r = self.P.param.params("s").get_range()
+        self.assertEqual(r['one'],1)
+        self.assertEqual(r['two'],2)
 
     def test_set_object_outside_bounds(self):
         p = self.P(e=6)


### PR DESCRIPTION
Right now, ObjectSelector accepts a list of objects from which to select, which works well when the objects have a meaningful `name` parameter or `__name__` attribute.  However, one often needs to switch between objects for which you want to use a different representation.  For instance if one defines a selector like this: 

```
   video = param.ObjectSelector(objects=["k27MJJLJNT4","aZ1G_Q7ovmc", "BjlQdOK3n5w"])
```

The user will be confronted with a bewildering set of meaningless choices.  Instead, it would be nice to provide a list of readable names associated with each object, as in:

```
    video = param.ObjectSelector(objects=dict(AnacondaCon18="k27MJJLJNT4",
                                              SciPy18="aZ1G_Q7ovmc", 
                                              ERDC17="BjlQdOK3n5w"))
```

That way a GUI selection widget can let the users choose between the readable names while internally selecting between the underlying objects.  

This PR adds this capability.  Now, if a user passes in a dict or an ordereddict for the objects (which previously has been a list), then ObjectSelector stores this dict in a `names` slot, then pulls out the values of the dictionary to use as the normal objects list as before.  The `names` dictionary is then consulted for `get_range()`, which returns the `named_objs` using the names dictionary entries where present, and otherwise the name or other repr.

This approach of keeping a separate `names` dictionary was chosen to improve backwards compatibility, so that the behavior of the existing slots is the same apart from in `get_range`.

This approach has been tested with ParamNB:

![image](https://user-images.githubusercontent.com/1695496/44939327-e02c0800-ad49-11e8-977e-c6b591fe98d4.png)

And with ParamBokeh:

![image](https://user-images.githubusercontent.com/1695496/44939364-2bdeb180-ad4a-11e8-85bd-80ddeb958b95.png)

However, it looks like Panel currently uses its own machinery for coming up with the names list, and ignores this support in Param:

![image](https://user-images.githubusercontent.com/1695496/44939386-56306f00-ad4a-11e8-97a6-12943c2aa771.png)

So Panel will need updating to use this functionality, but the other packages will not.