### PR TITLE
Batched parameter setting for watch mechanism

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -27,7 +27,7 @@ except:
     param_pager = None
 
 
-DISABLE = False # Move to param namespace object
+DISABLE_WATCH = False # Move to param namespace object
 
 VERBOSE = INFO - 1
 logging.addLevelName(VERBOSE, "VERBOSE")
@@ -499,7 +499,7 @@ class Parameter(object):
 
 
     def _call_subscribers(self, subscribers, what, old, new, obj):
-        if DISABLE: return
+        if DISABLE_WATCH: return
         for subscriber in subscribers:
             if not subscriber.batched:
                 subscriber.fn(Change(what=what,attribute=self._attrib_name,
@@ -912,7 +912,7 @@ class Parameters(object):
         positional arguments, but the keyword interface is preferred
         because it is more compact and can set multiple values.
         """
-        global DISABLE
+        global DISABLE_WATCH
         self_or_cls = self_.self_or_cls
         if args:
             if len(args)==2 and not args[0] in kwargs and not kwargs:
@@ -921,12 +921,12 @@ class Parameters(object):
                 raise ValueError("Invalid positional arguments for %s.set_param" %
                                  (self_or_cls.name))
 
-        DISABLE = True
+        DISABLE_WATCH = True
         for (k,v) in kwargs.items():
             if k not in self_or_cls.param.params():
                 raise ValueError("'%s' is not a parameter of %s"%(k,self_or_cls.name))
             setattr(self_or_cls,k,v)
-        DISABLE = False
+        DISABLE_WATCH = False
         self_or_cls._batch_call_subscribers(kwargs)
 
     def set_dynamic_time_fn(self_,time_fn,sublistattr=None):
@@ -1947,7 +1947,7 @@ class Parameterized(object):
 
     @bothmethod
     def _batch_call_subscribers(self, kwargs):
-        if DISABLE: return
+        if DISABLE_WATCH: return
 
         subscriber_sets = []
         for name, value in kwargs.items():

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1952,11 +1952,13 @@ class Parameterized(object):
         subscriber_sets = []
         for name, value in kwargs.items():
             if hasattr(self, '_param_subscribers'):
-                subscribers = self._param_subscribers[name]['value']
+                subscribers = self._param_subscribers[name]
             else:
-                subscribers = self.params(name).subscribers['value']
+                subscribers = self.params(name).subscribers
 
-            for subscriber in subscribers:
+            value_subscribers = subscribers.get('value', [])
+
+            for subscriber in value_subscribers:
                 subscriber_sets.append((subscriber, name))
 
         for subscriber,g in itertools.groupby(subscriber_sets, key=lambda t: t[0]):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -437,7 +437,7 @@ class Parameter(object):
 
     # Note: When initially created, a Parameter does not know which
     # Parameterized class owns it, nor does it know its names
-    # (attribute name, internal name). Once the owning Parmaeterized
+    # (attribute name, internal name). Once the owning Parameterized
     # class is created, _owner, _attrib_name, and _internal name are
     # set.
 
@@ -499,7 +499,7 @@ class Parameter(object):
 
 
     def _call_subscribers(self, subscribers, what, old, new, obj):
-        if DISABLE_WATCH: return
+        if self._owner is not None and self._owner.param.DISABLE_WATCH: return
         for subscriber in subscribers:
             if not subscriber.batched:
                 subscriber.fn(Change(what=what,attribute=self._attrib_name,
@@ -721,7 +721,7 @@ class Parameters(object):
         """
         self_.cls = cls
         self_.self = self
-
+        self_.DISABLE_WATCH = False
 
     @property
     def self_or_cls(self_):
@@ -912,7 +912,7 @@ class Parameters(object):
         positional arguments, but the keyword interface is preferred
         because it is more compact and can set multiple values.
         """
-        global DISABLE_WATCH
+        # global DISABLE_WATCH
         self_or_cls = self_.self_or_cls
         if args:
             if len(args)==2 and not args[0] in kwargs and not kwargs:
@@ -921,12 +921,12 @@ class Parameters(object):
                 raise ValueError("Invalid positional arguments for %s.set_param" %
                                  (self_or_cls.name))
 
-        DISABLE_WATCH = True
+        self_.DISABLE_WATCH = True
         for (k,v) in kwargs.items():
             if k not in self_or_cls.param.params():
                 raise ValueError("'%s' is not a parameter of %s"%(k,self_or_cls.name))
             setattr(self_or_cls,k,v)
-        DISABLE_WATCH = False
+        self_.DISABLE_WATCH = False
         self_or_cls._batch_call_subscribers(kwargs)
 
     def set_dynamic_time_fn(self_,time_fn,sublistattr=None):
@@ -1947,7 +1947,7 @@ class Parameterized(object):
 
     @bothmethod
     def _batch_call_subscribers(self, kwargs):
-        if DISABLE_WATCH: return
+        if self.param.DISABLE_WATCH: return
 
         subscriber_sets = []
         for name, value in kwargs.items():

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -248,7 +248,7 @@ def _m_caller(self,n):
 PInfo = namedtuple("PInfo","inst cls name pobj what")
 MInfo = namedtuple("MInfo","inst cls name mthd")
 Change = namedtuple("Change","what attribute obj cls old new")
-Subscriber = namedtuple('Subscriber', 'batched fn')
+Subscriber = namedtuple('Subscriber', 'batched fn what')
 
 
 class ParameterMetaclass(type):
@@ -1140,7 +1140,7 @@ class Parameters(object):
                 if parameter_attribute not in subscribers[parameter_name]:
                     subscribers[parameter_name][parameter_attribute] = []
 
-                subscriber = Subscriber(batched=batched, fn=fn)
+                subscriber = Subscriber(batched=batched, fn=fn, what=parameter_attribute)
                 getattr(subscribers[parameter_name][parameter_attribute],action)(subscriber)
             else:
                 subscribers = self_.cls.params(parameter_name).subscribers

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1117,16 +1117,9 @@ class Parameters(object):
             return MInfo(inst=inst,cls=cls,name=attr,mthd=getattr(src,attr))
 
 
-    def _watch(self_,action,fn,parameter_name,parameter_attribute=None):
+    def _watch(self_,action,fn,parameter_names,parameter_attribute=None):
         #cls,obj = (slf_or_cls,None) if isinstance(slf_or_cls,ParameterizedMetaclass) else (slf_or_cls.__class__,slf_or_cls)
-
-        if not isinstance(parameter_name, list):
-            parameter_names = [parameter_name]
-            batched = False
-        else:
-            parameter_names = parameter_name
-            batched = True
-
+        batched = len(parameter_names) > 1
         for parameter_name in parameter_names:
             assert parameter_name in self_.cls.params()
 
@@ -1150,11 +1143,11 @@ class Parameters(object):
                 subscriber = Subscriber(batched=batched, fn=fn)
                 getattr(subscribers[parameter_attribute],action)(subscriber)
 
-    def watch(self_,fn,parameter_name,parameter_attribute=None):
-        self_._watch('append',fn,parameter_name,parameter_attribute)
+    def watch(self_,fn,parameter_names,parameter_attribute=None):
+        self_._watch('append',fn,parameter_names,parameter_attribute)
 
-    def unwatch(self_,fn,parameter_name,parameter_attribute=None):
-        self_._watch('remove',fn,parameter_name,parameter_attribute)
+    def unwatch(self_,fn,parameter_names,parameter_attribute=None):
+        self_._watch('remove',fn,parameter_names,parameter_attribute)
 
 
     # Instance methods


### PR DESCRIPTION
This PR is *very* WIP and I don't think it should be merged without a lot of work. All the first commit shows is that this should be possible, *hopefully* without requiring very deep changes to how watching works.

Major Issues that need to be addressed:

- [x] Uses a ``groupby`` on the callback identity: this is not a safe assumption (I believe this is fixed)
- [ ]  The `DISABLE` global variable should be moved the the namespace object and renamed.
- [ ] I'm assuming the 'what' is 'value' which I *think* is ok for `set_param` (as you can only set value there)
- [ ] Probably others I haven't thought of yet!

Instance example:

```python
import param
class Foo(param.Parameterized):
   a = param.Number(default=1)
   b = param.Number(default=3)

def foo(*la): print('CHANGES>' , la)
f = Foo()
f.param.watch(foo, ['a','b'])

f.set_param(a=32, b=33)
CHANGES> (Change(what='value', attribute='a', obj=Foo(a=32, b=33, name='Foo00002'), cls=<class '__main__.Foo'>, old=1, new=32), Change(what='value', attribute='b', obj=Foo(a=32, b=33, name='Foo00002'), cls=<class '__main__.Foo'>, old=3, new=33))
```

Class example:

```python
import param
class Foo(param.Parameterized):
   a = param.Number(default=1)
   b = param.Number(default=3)

def foo(*la): print('CHANGES>' , la)
Foo.param.watch(foo, ['a','b'])

Foo.set_param(a=455, b=33)
CHANGES> (Change(what='value', attribute='a', obj=<class '__main__.Foo'>, cls=<class '__main__.Foo'>, old=455, new=455), Change(what='value', attribute='b', obj=<class '__main__.Foo'>, cls=<class '__main__.Foo'>, old=33, new=33))
```

I'm also not a huge fan of these `Change` objects. I think they should be an option you explicitly enable to get as much information as possible: I think the default should be to just supply the new values on a change as kwargs.

