### PR TITLE
param_depends_on returns all parameters for methods

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -230,7 +230,8 @@ def depends(func, *dependencies, **kw):
 
 
 def _params_depended_on(mthing,params):
-    for d in getattr(mthing.mthd,"_dinfo",{})['dependencies']:
+    dinfo = getattr(mthing.mthd,"_dinfo", {})
+    for d in dinfo.get('dependencies',list(mthing.cls.params())):
         thing = (mthing.inst or mthing.cls).param._spec_to_obj(d)
         if isinstance(thing,PInfo):
             params.append(thing)


### PR DESCRIPTION
This PR ensures that undecorated methods by default depend on all parameters. This PR will ensure that ``panel`` will listen to all parameter changes by default while holoviews will continue to only listen to changes that have been explicitly declared.