### PR TITLE
Param depends improvements

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -232,7 +232,7 @@ def depends(func, *dependencies, **kw):
 def _params_depended_on(mthing):
     params = []
     dinfo = getattr(mthing.mthd,"_dinfo", {})
-    for d in dinfo.get('dependencies',list(mthing.cls.params())):
+    for d in dinfo.get('dependencies',list(mthing.cls.param.params())):
         things = (mthing.inst or mthing.cls).param._spec_to_obj(d)
         for thing in things:
             if isinstance(thing,PInfo):
@@ -1099,11 +1099,11 @@ class Parameters(object):
 
         if attr == 'param':
             dependencies = self_._spec_to_obj(obj[1:])
-            for p in src.params():
+            for p in src.param.params():
                 dependencies += src.param._spec_to_obj(p)
             return dependencies
-        elif attr in src.params():
-            info = PInfo(inst=inst,cls=cls,name=attr,pobj=src.params(attr),
+        elif attr in src.param.params():
+            info = PInfo(inst=inst,cls=cls,name=attr,pobj=src.param.params(attr),
                           what=what if what!='' else 'value')
         else:
             info = MInfo(inst=inst,cls=cls,name=attr,mthd=getattr(src,attr))
@@ -1113,7 +1113,7 @@ class Parameters(object):
     def _watch(self_,action,fn,parameter_name,parameter_attribute=None):
         #cls,obj = (slf_or_cls,None) if isinstance(slf_or_cls,ParameterizedMetaclass) else (slf_or_cls.__class__,slf_or_cls)
 
-        assert parameter_name in self_.cls.params()
+        assert parameter_name in self_.cls.param.params()
 
         if parameter_attribute is None:
             parameter_attribute = "value"
@@ -1126,7 +1126,7 @@ class Parameters(object):
                 subscribers[parameter_name][parameter_attribute] = []
             getattr(subscribers[parameter_name][parameter_attribute],action)(fn)
         else:
-            subscribers = self_.cls.params(parameter_name).subscribers
+            subscribers = self_.cls.param.params(parameter_name).subscribers
             if parameter_attribute not in subscribers:
                 subscribers[parameter_attribute] = []
             getattr(subscribers[parameter_attribute],action)(fn)

--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -1,0 +1,70 @@
+"""
+Unit test for param.depends.
+"""
+
+
+import param
+from . import API1TestCase
+
+
+class TestParamDepends(API1TestCase):
+
+    def setUp(self):
+        class P(param.Parameterized):
+            a = param.Parameter()
+            b = param.Parameter()
+
+            @param.depends('a')
+            def single_parameter(self):
+                pass
+
+            @param.depends('a:constant')
+            def constant(self):
+                pass
+
+            @param.depends('a.param')
+            def nested(self):
+                pass
+
+        self.P = P
+
+    def test_param_depends_instance(self):
+        p = self.P()
+        pinfos = p.param.params_depended_on('single_parameter')
+        self.assertEqual(len(pinfos), 1)
+        pinfo = pinfos[0]
+        self.assertIs(pinfo.cls, self.P)
+        self.assertIs(pinfo.inst, p)
+        self.assertEqual(pinfo.name, 'a')
+        self.assertEqual(pinfo.what, 'value')
+
+    def test_param_depends_class(self):
+        pinfos = self.P.param.params_depended_on('single_parameter')
+        self.assertEqual(len(pinfos), 1)
+        pinfo = pinfos[0]
+        self.assertIs(pinfo.cls, self.P)
+        self.assertIs(pinfo.inst, None)
+        self.assertEqual(pinfo.name, 'a')
+        self.assertEqual(pinfo.what, 'value')
+
+    def test_param_depends_constant(self):
+        pinfos = self.P.param.params_depended_on('constant')
+        self.assertEqual(len(pinfos), 1)
+        pinfo = pinfos[0]
+        self.assertIs(pinfo.cls, self.P)
+        self.assertIs(pinfo.inst, None)
+        self.assertEqual(pinfo.name, 'a')
+        self.assertEqual(pinfo.what, 'constant')
+
+    def test_param_depends_nested(self):
+        inst = self.P(a=self.P())
+        pinfos = inst.param.params_depended_on('nested')
+        self.assertEqual(len(pinfos), 4)
+        pinfo = pinfos[0]
+        self.assertIs(pinfo.cls, self.P)
+        self.assertIs(pinfo.inst, inst)
+        self.assertEqual(pinfo.name, 'a')
+        self.assertEqual(pinfo.what, 'value')
+        for info, p in zip(pinfos[1:], ['name', 'a', 'b']):
+            self.assertEqual(info.name, p)
+            self.assertIs(info.inst, inst.a)

--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -60,11 +60,13 @@ class TestParamDepends(API1TestCase):
         inst = self.P(a=self.P())
         pinfos = inst.param.params_depended_on('nested')
         self.assertEqual(len(pinfos), 4)
-        pinfo = pinfos[0]
+        pinfos = {(pi.inst, pi.name): pi for pi in pinfos}
+        pinfo = pinfos[(inst, 'a')]
         self.assertIs(pinfo.cls, self.P)
         self.assertIs(pinfo.inst, inst)
         self.assertEqual(pinfo.name, 'a')
         self.assertEqual(pinfo.what, 'value')
-        for info, p in zip(pinfos[1:], ['name', 'a', 'b']):
+        for p in ['name', 'a', 'b']:
+            info = pinfos[(inst.a, p)]
             self.assertEqual(info.name, p)
             self.assertIs(info.inst, inst.a)


### PR DESCRIPTION
Refactor of param depends and added support for listening to all subobject parameters with ``subobject.param`` spec.

- [x] Add unit tests