### PR TITLE
Only trigger watch callbacks on parameter change

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -810,7 +810,7 @@ class Parameters(object):
     @classmethod
     def _changed(cls, change):
         """
-        Predicate that determines whether a Change objects has actually
+        Predicate that determines whether a Change object has actually
         changed such that old!=new.
         """
         try:  # To be improved by adding better machinery to test equality for complex types

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -813,7 +813,7 @@ class Parameters(object):
         Predicate that determines whether a Change objects has actually
         changed such that old!=new.
         """
-        try:  # To be improve by value equality testing machinery
+        try:  # To be improved by adding better machinery to test equality for complex types
             return (change.old != change.new)
         except:
             return True

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -1,0 +1,43 @@
+"""
+Unit test for watch mechanism
+"""
+from . import API1TestCase
+
+import param
+
+class TestWatch(API1TestCase):
+
+    class SimpleWatchExample(param.Parameterized):
+        a = param.Integer(default=0)
+
+    def setUp(self):
+        super(TestWatch, self).setUp()
+        self.switch = False
+
+    def test_triggered_when_changed(self):
+        def switcher(*args):
+            self.switch = (not self.switch)
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch(switcher, 'a')
+        obj.a = 1
+        self.assertEqual(self.switch, True)
+        obj.a = 2
+        self.assertEqual(self.switch, False)
+
+
+    def test_untriggered_when_unchanged(self):
+        def switcher(*args):
+            self.switch = (not self.switch)
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch(switcher, 'a')
+        obj.a = 1
+        self.assertEqual(self.switch, True)
+        obj.a = 1
+        self.assertEqual(self.switch, True)
+
+if __name__ == "__main__":
+    import nose
+    nose.runmodule()
+


### PR DESCRIPTION
Following the proposal in #269, this PR updates the watch mechanism to ensure changes have actually occurred before triggering the defined watch callbacks.

My next step will be to write another PR that works on the new `trigger` method and batching.