### PR TITLE
Added watch_values and unwatch_values methods

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1172,16 +1172,28 @@ class Parameters(object):
         self_._watch('append',subscriber,parameter_name,parameter_attribute)
 
     def unwatch(self_,fn,parameter_name,parameter_attribute=None):
-        subscriber = Subscriber(fn=fn, mode='args')
-        self_._watch('remove',subscriber,parameter_name,parameter_attribute)
+        """
+        Unwatch subscribers set either with watch or watch_values.
+        """
+        unwatched = False
+        try:
+            subscriber = Subscriber(fn=fn, mode='args')
+            self_._watch('remove',subscriber,parameter_name,parameter_attribute)
+            unwatched = True
+        except: pass
+        try:
+            subscriber = Subscriber(fn=fn, mode='kwargs')
+            self_._watch('remove',subscriber,parameter_name,parameter_attribute)
+            unwatched = True
+        except: pass
+
+        if not unwatched:
+            self_.warning('No effect unwatching subscriber that was not being watched')
 
     def watch_values(self_,fn,parameter_name,parameter_attribute=None):
         subscriber = Subscriber(fn=fn, mode='kwargs')
         self_._watch('append',subscriber,parameter_name,parameter_attribute)
 
-    def unwatch_values(self_,fn,parameter_name,parameter_attribute=None):
-        subscriber = Subscriber(fn=fn, mode='kwargs')
-        self_._watch('remove',subscriber,parameter_name,parameter_attribute)
 
 
     # Instance methods

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -249,7 +249,7 @@ def _m_caller(self,n):
 PInfo = namedtuple("PInfo","inst cls name pobj what")
 MInfo = namedtuple("MInfo","inst cls name method")
 Change = namedtuple("Change","what name obj cls old new")
-
+Subscriber = namedtuple("Subscriber","fn mode")
 
 class ParameterMetaclass(type):
     """
@@ -1135,7 +1135,7 @@ class Parameters(object):
         return [info]
 
 
-    def _watch(self_,action,fn,parameter_name,parameter_attribute=None):
+    def _watch(self_,action,subscriber,parameter_name,parameter_attribute=None):
         #cls,obj = (slf_or_cls,None) if isinstance(slf_or_cls,ParameterizedMetaclass) else (slf_or_cls.__class__,slf_or_cls)
 
         assert parameter_name in self_.cls.param.params()
@@ -1149,12 +1149,12 @@ class Parameters(object):
                 subscribers[parameter_name] = {}
             if parameter_attribute not in subscribers[parameter_name]:
                 subscribers[parameter_name][parameter_attribute] = []
-            getattr(subscribers[parameter_name][parameter_attribute],action)(fn)
+            getattr(subscribers[parameter_name][parameter_attribute],action)(subscriber)
         else:
             subscribers = self_.cls.param.params(parameter_name).subscribers
             if parameter_attribute not in subscribers:
                 subscribers[parameter_attribute] = []
-            getattr(subscribers[parameter_attribute],action)(fn)
+            getattr(subscribers[parameter_attribute],action)(subscriber)
 
     def watch(self_,fn,parameter_name,parameter_attribute=None):
         self_._watch('append',fn,parameter_name,parameter_attribute)

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -37,6 +37,18 @@ class TestWatch(API1TestCase):
         obj.a = 1
         self.assertEqual(self.accumulator, 1)
 
+
+    def test_untriggered_when_unwatched(self):
+        def accumulator(change):
+            self.accumulator += change.new
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch(accumulator, 'a')
+        obj.a = 1
+        self.assertEqual(self.accumulator, 1)
+        obj.param.unwatch(accumulator, 'a')
+        obj.a = 2
+        self.assertEqual(self.accumulator, 1)
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -49,6 +49,55 @@ class TestWatch(API1TestCase):
         obj.param.unwatch(accumulator, 'a')
         obj.a = 2
         self.assertEqual(self.accumulator, 1)
+
+
+
+class TestWatchValues(API1TestCase):
+
+    class SimpleWatchExample(param.Parameterized):
+        a = param.Integer(default=0)
+
+    def setUp(self):
+        super(TestWatchValues, self).setUp()
+        self.accumulator = 0
+
+    def test_triggered_when_values_changed(self):
+        def accumulator(a):
+            self.accumulator += a
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch_values(accumulator, 'a')
+        obj.a = 1
+        self.assertEqual(self.accumulator, 1)
+        obj.a = 2
+        self.assertEqual(self.accumulator, 3)
+
+
+    def test_untriggered_when_values_unchanged(self):
+        def accumulator(a):
+            self.accumulator += a
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch_values(accumulator, 'a')
+        obj.a = 1
+        self.assertEqual(self.accumulator, 1)
+        obj.a = 1
+        self.assertEqual(self.accumulator, 1)
+
+
+    def test_untriggered_when_values_unwatched(self):
+        def accumulator(a):
+            self.accumulator += a
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch_values(accumulator, 'a')
+        obj.a = 1
+        self.assertEqual(self.accumulator, 1)
+        obj.param.unwatch_values(accumulator, 'a')
+        obj.a = 2
+        self.assertEqual(self.accumulator, 1)
+
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -93,7 +93,7 @@ class TestWatchValues(API1TestCase):
         obj.param.watch_values(accumulator, 'a')
         obj.a = 1
         self.assertEqual(self.accumulator, 1)
-        obj.param.unwatch_values(accumulator, 'a')
+        obj.param.unwatch(accumulator, 'a')
         obj.a = 2
         self.assertEqual(self.accumulator, 1)
 

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -12,30 +12,30 @@ class TestWatch(API1TestCase):
 
     def setUp(self):
         super(TestWatch, self).setUp()
-        self.switch = False
+        self.accumulator = 0
 
     def test_triggered_when_changed(self):
-        def switcher(*args):
-            self.switch = (not self.switch)
+        def accumulator(change):
+            self.accumulator += change.new
 
         obj = self.SimpleWatchExample()
-        obj.param.watch(switcher, 'a')
+        obj.param.watch(accumulator, 'a')
         obj.a = 1
-        self.assertEqual(self.switch, True)
+        self.assertEqual(self.accumulator, 1)
         obj.a = 2
-        self.assertEqual(self.switch, False)
+        self.assertEqual(self.accumulator, 3)
 
 
     def test_untriggered_when_unchanged(self):
-        def switcher(*args):
-            self.switch = (not self.switch)
+        def accumulator(change):
+            self.accumulator += change.new
 
         obj = self.SimpleWatchExample()
-        obj.param.watch(switcher, 'a')
+        obj.param.watch(accumulator, 'a')
         obj.a = 1
-        self.assertEqual(self.switch, True)
+        self.assertEqual(self.accumulator, 1)
         obj.a = 1
-        self.assertEqual(self.switch, True)
+        self.assertEqual(self.accumulator, 1)
 
 if __name__ == "__main__":
     import nose


### PR DESCRIPTION
Using `watch_values` is useful when you only care about value changes and don't want to handle `Change` objects. In this case, the changed values are passed as `**kwargs`.

Ready for review/merge once the tests are green.