### PR TITLE
Renamed 'subscribers' to 'watchers' throughout

### DIFF
--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -70,7 +70,7 @@ class TestWatch(API1TestCase):
 
         obj.param.unwatch(accumulator, 'a')
         self.log_handler.assertEndsWith('WARNING',
-                            'No effect unwatching subscriber that was not being watched')
+                            'No effect unwatching watcher that was not being watched')
 
 
 


### PR DESCRIPTION
Addresses #273. Note this is a simple search and replace: I am assuming there are no backwards compatibility implications (e.g renaming a slot) because this whole mechanism is new enough that it hasn't been released yet.