### PR TITLE
Ensured that param changed comparisons fail on array

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -812,7 +812,7 @@ class Parameters(object):
         changed such that old!=new.
         """
         try:  # To be improved by adding better machinery to test equality for complex types
-            return (change.old != change.new)
+            return bool(change.old != change.new)
         except:
             return True
 


### PR DESCRIPTION
The code was letting array comparisons slip past which meant they would fail when the boolean arrays were being coerced to bools. This PR ensures the coercion happens inside the try/except, which means that it fails gracefully.