### PR TITLE
Add Comparator to detect changes in arbitrary objects

### DIFF
--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -10,8 +10,7 @@ import param
 class TestWatch(API1TestCase):
 
     class SimpleWatchExample(param.Parameterized):
-        a = param.Integer(default=0)
-
+        a = param.Parameter(default=0)
 
     @classmethod
     def setUpClass(cls):
@@ -47,6 +46,20 @@ class TestWatch(API1TestCase):
         self.assertEqual(self.accumulator, 1)
         obj.a = 1
         self.assertEqual(self.accumulator, 1)
+
+
+    def test_triggered_when_unchanged_complex_type(self):
+        def accumulator(change):
+            self.accumulator += 1
+
+        obj = self.SimpleWatchExample()
+        obj.param.watch(accumulator, 'a')
+        subobj = object()
+        obj.a = subobj
+        self.assertEqual(self.accumulator, 1)
+        obj.a = subobj
+        self.assertEqual(self.accumulator, 2)
+
 
     def test_triggered_when_unchanged_if_not_onlychanged(self):
         def accumulator(change):


### PR DESCRIPTION
Implements what I suggested in https://github.com/ioam/param/issues/269 and supersedes https://github.com/ioam/param/pull/277 if we decide to go with this approach. I haven't yet defined any comparisons for types beyond Python literals. Here's what a comparison function definition for a NumPy array would look like (without explicitly importing numpy and registering the equality by type):

```python
def is_numpy(obj):
    if 'numpy' not in sys.modules: return False
    import numpy as np
    return isinstance(obj, np.ndarray)

def array_equal(obj1, obj2):
    import numpy as np
    return np.array_equal(obj1, obj2)

Comparator.equalities[is_numpy] = array_equal

# If NumPy can be imported it's much simpler
Comparator.equalities[np.ndarray] = np.array_equal
```