### PR TITLE
Fixed bugs in Comparator when type changes

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -747,7 +747,7 @@ class Comparator(object):
 
     @classmethod
     def compare_iterator(cls, obj1, obj2):
-        if (len(obj1) != len(obj2)) or type(obj1) != type(obj2):
+        if type(obj1) != type(obj2) or len(obj1) != len(obj2):
             return False
         for o1, o2 in zip(obj1, obj2):
             if not cls.is_equal(o1, o2):
@@ -756,7 +756,7 @@ class Comparator(object):
 
     @classmethod
     def compare_mapping(cls, obj1, obj2):
-        if len(obj1) != len(obj2): return False
+        if type(obj1) != type(obj2) or len(obj1) != len(obj2): return False
         for k in obj1:
             if k in obj2:
                 if not cls.is_equal(obj1[k], obj2[k]):

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -61,6 +61,30 @@ class TestWatch(API1TestCase):
         self.assertEqual(self.accumulator, 3)
 
 
+    def test_triggered_when_changed_iterator_type(self):
+        def accumulator(change):
+            self.accumulator = change.new
+
+        obj = SimpleWatchExample()
+        obj.param.watch(accumulator, 'a')
+        obj.a = []
+        self.assertEqual(self.accumulator, [])
+        obj.a = tuple()
+        self.assertEqual(self.accumulator, tuple())
+
+
+    def test_triggered_when_changed_mapping_type(self):
+        def accumulator(change):
+            self.accumulator = change.new
+
+        obj = SimpleWatchExample()
+        obj.param.watch(accumulator, 'a')
+        obj.a = []
+        self.assertEqual(self.accumulator, [])
+        obj.a = {}
+        self.assertEqual(self.accumulator, {})
+
+
     def test_untriggered_when_unchanged(self):
         def accumulator(change):
             self.accumulator += change.new


### PR DESCRIPTION
Simple bug fix to guard against errors when the type of a parameter changes.