### PR TITLE
Ensure batching happens on instances Parameters object

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1043,7 +1043,6 @@ class Parameters(object):
         positional arguments, but the keyword interface is preferred
         because it is more compact and can set multiple values.
         """
-        in_batched = self_.self_or_cls.param._BATCH_WATCH
         self_.self_or_cls.param._BATCH_WATCH = True
         self_or_cls = self_.self_or_cls
         if args:
@@ -1059,7 +1058,7 @@ class Parameters(object):
             setattr(self_or_cls,k,v)
 
         self_._batch_call_watchers()
-        self_.self_or_cls.param._BATCH_WATCH = in_batched
+        self_.self_or_cls.param._BATCH_WATCH = False
 
     def set_dynamic_time_fn(self_,time_fn,sublistattr=None):
         """

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -32,6 +32,7 @@ class SimpleWatchExample(param.Parameterized):
     a = param.Parameter(default=0)
     b = param.Parameter(default=0)
     c = param.Parameter(default=0)
+    d = param.Parameter(default=0)
 
 
 class SimpleWatchSubclass(SimpleWatchExample):
@@ -247,6 +248,43 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[1].name, 'c')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 42)
+
+
+    def test_nested_batched_watch(self):
+
+        accumulator = Accumulator()
+
+        obj = SimpleWatchExample()
+
+        def set_param(*changes):
+            obj.param.set_param(a=10, d=12)
+
+        obj.param.watch(accumulator, ['a', 'b','c', 'd'])
+        obj.param.watch(set_param, ['b', 'c'])
+        obj.param.set_param(b=23, c=42)
+
+        self.assertEqual(accumulator.call_count(), 2)
+        args = accumulator.args_for_call(0)
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].name, 'b')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 23)
+
+        self.assertEqual(args[1].name, 'c')
+        self.assertEqual(args[1].old, 0)
+        self.assertEqual(args[1].new, 42)
+
+        args = accumulator.args_for_call(1)
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].name, 'a')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 10)
+
+        self.assertEqual(args[1].name, 'd')
+        self.assertEqual(args[1].old, 0)
+        self.assertEqual(args[1].new, 12)
 
 
 

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -34,6 +34,10 @@ class SimpleWatchExample(param.Parameterized):
     c = param.Parameter(default=0)
 
 
+class SimpleWatchSubclass(SimpleWatchExample):
+    pass
+
+
 
 class TestWatch(API1TestCase):
 
@@ -221,6 +225,29 @@ class TestWatch(API1TestCase):
                 self.assertEqual(args[1].new, 42)
             else:
                 raise Exception('Invalid number of arguments')
+
+
+    def test_subclass_batched_watch(self):
+
+        accumulator = Accumulator()
+
+        obj = SimpleWatchSubclass()
+
+        obj.param.watch(accumulator, ['b','c'])
+        obj.param.set_param(b=23, c=42)
+
+        self.assertEqual(accumulator.call_count(), 1)
+        args = accumulator.args_for_call(0)
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].name, 'b')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 23)
+
+        self.assertEqual(args[1].name, 'c')
+        self.assertEqual(args[1].old, 0)
+        self.assertEqual(args[1].new, 42)
+
 
 
 


### PR DESCRIPTION
The batching queues and the flag were all being set on a class' Parameters (i.e. ``.param``) object, which caused very strange behavior when there were multiple batched calls triggering each other. Additionally unconditionally returning the BATCHED flag to False once done with batching was disabling batching entirely for nested batch calls.