### PR TITLE
Fixed bug when watching class parameter

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -598,6 +598,7 @@ class Parameter(object):
             watchers = getattr(obj,"_param_watchers",{}).get(self._attrib_name,{}).get('value',self.watchers.get("value",[]))
 
         change = Change(what='value',name=self._attrib_name,obj=obj,cls=self._owner,old=_old,new=val)
+        obj = self._owner if obj is None else obj
         for s in watchers:
             obj.param._call_watcher(s, change)
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1547,7 +1547,9 @@ class ParameterizedMetaclass(type):
 
         if parameter and not isinstance(value,Parameter):
             if owning_class != mcs:
-                type.__setattr__(mcs,attribute_name,copy.copy(parameter))
+                parameter = copy.copy(parameter)
+                parameter._owner = mcs
+                type.__setattr__(mcs,attribute_name,parameter)
             mcs.__dict__[attribute_name].__set__(None,value)
 
         else:

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -202,7 +202,7 @@ class TestWatch(API1TestCase):
 
         accumulator = Accumulator()
 
-        obj = SimpleWatchExample
+        obj = SimpleWatchSubclass
         watcher = obj.param.watch(accumulator, ['a','b'])
         obj.param.set_param(a=23, b=42)
 

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -198,6 +198,30 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[1].new, 42)
 
 
+    def test_simple_class_batched_watch(self):
+
+        accumulator = Accumulator()
+
+        obj = SimpleWatchExample
+        watcher = obj.param.watch(accumulator, ['a','b'])
+        obj.param.set_param(a=23, b=42)
+
+        self.assertEqual(accumulator.call_count(), 1)
+        args = accumulator.args_for_call(0)
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].name, 'a')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 23)
+
+        self.assertEqual(args[1].name, 'b')
+        self.assertEqual(args[1].old, 0)
+        self.assertEqual(args[1].new, 42)
+
+        SimpleWatchExample.param.unwatch(watcher)
+        obj.param.set_param(a=0, b=0)
+
+
     def test_simple_batched_watch_callback_reuse(self):
 
         accumulator = Accumulator()


### PR DESCRIPTION
In the previous PR which fixed batching I assumed that the ``obj`` would always be provided but if you look at ``Parameterized.__set__`` it is not provided if ``self._owner`` is the object.