### PR TITLE
Introduced types field for watch Event objects

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1028,6 +1028,9 @@ class Parameters(object):
 
 
     def _update_event_type(self_, watcher, event, triggered):
+        """
+        Returns an updated Event object with the type field set appropriately.
+        """
         if triggered:
             event_type = 'triggered'
         else:

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -166,6 +166,7 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 2)
+        self.assertEqual(args[0].type, 'changed')
 
         obj.b = 3
         self.assertEqual(accumulator.call_count(), 2)
@@ -175,6 +176,7 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'b')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 3)
+        self.assertEqual(args[0].type, 'changed')
 
 
     def test_simple_batched_watch(self):
@@ -192,10 +194,12 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 23)
+        self.assertEqual(args[0].type, 'changed')
 
         self.assertEqual(args[1].name, 'b')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 42)
+        self.assertEqual(args[1].type, 'changed')
 
 
     def test_simple_class_batched_watch(self):
@@ -213,10 +217,12 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 23)
+        self.assertEqual(args[0].type, 'changed')
 
         self.assertEqual(args[1].name, 'b')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 42)
+        self.assertEqual(args[1].type, 'changed')
 
         SimpleWatchExample.param.unwatch(watcher)
         obj.param.set_param(a=0, b=0)
@@ -239,15 +245,18 @@ class TestWatch(API1TestCase):
                 self.assertEqual(args[0].name, 'c')
                 self.assertEqual(args[0].old, 0)
                 self.assertEqual(args[0].new, 99)
+                self.assertEqual(args[0].type, 'changed')
 
             elif len(args) == 2: # ['a', 'b']
                 self.assertEqual(args[0].name, 'a')
                 self.assertEqual(args[0].old, 0)
                 self.assertEqual(args[0].new, 23)
+                self.assertEqual(args[0].type, 'changed')
 
                 self.assertEqual(args[1].name, 'b')
                 self.assertEqual(args[1].old, 0)
                 self.assertEqual(args[1].new, 42)
+                self.assertEqual(args[0].type, 'changed')
             else:
                 raise Exception('Invalid number of arguments')
 
@@ -268,10 +277,12 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'b')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 23)
+        self.assertEqual(args[0].type, 'changed')
 
         self.assertEqual(args[1].name, 'c')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 42)
+        self.assertEqual(args[1].type, 'changed')
 
 
     def test_nested_batched_watch(self):
@@ -294,10 +305,12 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'b')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 23)
+        self.assertEqual(args[0].type, 'changed')
 
         self.assertEqual(args[1].name, 'c')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 42)
+        self.assertEqual(args[1].type, 'changed')
 
         args = accumulator.args_for_call(1)
         self.assertEqual(len(args), 2)
@@ -305,10 +318,12 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 10)
+        self.assertEqual(args[0].type, 'changed')
 
         self.assertEqual(args[1].name, 'd')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 12)
+        self.assertEqual(args[1].type, 'changed')
 
 
 
@@ -428,6 +443,7 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 0)
+        self.assertEqual(args[0].type, 'triggered')
 
     def test_simple_trigger_one_param_change(self):
         accumulator = Accumulator()
@@ -443,11 +459,13 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 42)
+        self.assertEqual(args[0].type, 'changed')
 
         args = accumulator.args_for_call(1)
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 42)
         self.assertEqual(args[0].new, 42)
+        self.assertEqual(args[0].type, 'triggered')
 
     def test_simple_trigger_two_params(self):
         accumulator = Accumulator()
@@ -460,10 +478,12 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[0].name, 'a')
         self.assertEqual(args[0].old, 0)
         self.assertEqual(args[0].new, 0)
+        self.assertEqual(args[0].type, 'triggered')
 
         self.assertEqual(args[1].name, 'b')
         self.assertEqual(args[1].old, 0)
         self.assertEqual(args[1].new, 0)
+        self.assertEqual(args[1].type, 'triggered')
 
 
 if __name__ == "__main__":

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -116,15 +116,27 @@ class TestWatch(API1TestCase):
 
 
     def test_triggered_when_unchanged_if_not_onlychanged(self):
-        def accumulator(change):
-            self.accumulator += change.new
-
+        accumulator = Accumulator()
         obj = SimpleWatchExample()
         obj.param.watch(accumulator, 'a', onlychanged=False)
         obj.a = 1
-        self.assertEqual(self.accumulator, 1)
+
+        self.assertEqual(accumulator.call_count(), 1)
+        args = accumulator.args_for_call(0)
+        self.assertEqual(len(args), 1)
+        self.assertEqual(args[0].name, 'a')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 1)
+        self.assertEqual(args[0].type, 'set')
+
         obj.a = 1
-        self.assertEqual(self.accumulator, 2)
+        args = accumulator.args_for_call(1)
+        self.assertEqual(len(args), 1)
+        self.assertEqual(args[0].name, 'a')
+        self.assertEqual(args[0].old, 1)
+        self.assertEqual(args[0].new, 1)
+        self.assertEqual(args[0].type, 'set')
+
 
 
     def test_untriggered_when_unwatched(self):
@@ -333,7 +345,6 @@ class TestWatch(API1TestCase):
 
         obj.param.watch(accumulator, ['b','c'], onlychanged=False)
         obj.param.set_param(b=0, c=0)
-
 
         self.assertEqual(accumulator.call_count(), 1)
 

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -326,7 +326,29 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[1].type, 'changed')
 
 
+    def test_nested_batched_watch_not_onlychanged(self):
+        accumulator = Accumulator()
 
+        obj = SimpleWatchSubclass()
+
+        obj.param.watch(accumulator, ['b','c'], onlychanged=False)
+        obj.param.set_param(b=0, c=0)
+
+
+        self.assertEqual(accumulator.call_count(), 1)
+
+        args = accumulator.args_for_call(0)
+        self.assertEqual(len(args), 2)
+
+        self.assertEqual(args[0].name, 'b')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 0)
+        self.assertEqual(args[0].type, 'set')
+
+        self.assertEqual(args[1].name, 'c')
+        self.assertEqual(args[1].old, 0)
+        self.assertEqual(args[1].new, 0)
+        self.assertEqual(args[1].type, 'set')
 
 class TestWatchValues(API1TestCase):
 


### PR DESCRIPTION
This PR lets `Event` objects declare their type: either 'set', 'changed' or 'triggered'. If 'set', then the event was due to anything where `onlychanged=False`, if 'changed' then `onlychanged=True` and 'triggered' means the `trigger` methods was used.

- [x] Add unit tests