### PR TITLE
Fixed bug when batched watch callback sets other parameters

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1004,8 +1004,8 @@ class Parameters(object):
                 raise ValueError("'%s' is not a parameter of %s"%(k,self_or_cls.name))
             setattr(self_or_cls,k,v)
 
-        self_._batch_call_watchers()
         self_.self_or_cls.param._BATCH_WATCH = False
+        self_._batch_call_watchers()
 
 
     def trigger(self_, *param_names):

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -191,6 +191,26 @@ class TestWatch(API1TestCase):
         self.assertEqual(args[0].type, 'changed')
 
 
+    def test_nested_batched_watch_setattr(self):
+
+        obj = SimpleWatchExample()
+
+        accumulator = Accumulator()
+        watcher = obj.param.watch(accumulator, ['a', 'c'])
+
+        def set_c(*events):
+            obj.c = 3
+
+        watcher2 = obj.param.watch(set_c, ['a', 'b'])
+
+        obj.param.set_param(a=2)
+        self.assertEqual(obj.c, 3)
+
+        # Change inside watch callback should have triggered
+        # second call to accumulator
+        self.assertEqual(accumulator.call_count(), 2)
+
+
     def test_simple_batched_watch(self):
 
         accumulator = Accumulator()


### PR DESCRIPTION
This bug took me a long time to track down. Currently when a watch callback is triggered in batched mode any changes that callback makes to another parameter will not trigger watchers on those parameters. This is because these events will simply continue to be queued and that queue won't be processed until the next time a batched callback comes along. Therefore batching mode should be disabled before any other updates are processed.

The alternative here would be for ``batch_callbacks`` to process the queue in a while loop until it is empty, i.e. after each watcher is called any new events added would be added to the queue to process. That provides no actual benefits over this simpler approach though.

Been wondering for a week why the play button icon wasn't updating when I toggled it.